### PR TITLE
add worker install

### DIFF
--- a/.github/workflows/fake-release.yaml
+++ b/.github/workflows/fake-release.yaml
@@ -12,7 +12,8 @@ jobs:
     name: Create fake release
     runs-on: ubuntu-20.04
     env:
-      PRIMAZA_CONFIG_FILE: primaza_config_${{ github.event.inputs.version }}.yaml
+      PRIMAZA_CONFIG_FILE: primaza_main_config_${{ github.event.inputs.version }}.yaml
+      WORKER_CONFIG_FILE: primaza_worker_config_${{ github.event.inputs.version }}.yaml
     steps:
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -33,13 +34,13 @@ jobs:
           ../../bin/kustomize edit set image controller=${{ github.event.inputs.version }}
           cd ../../..
           scripts/bin/kustomize build scripts/config/default > ${PRIMAZA_CONFIG_FILE}
+          scripts/bin/kustomize build scripts//config/crd > ${WORKER_CONFIG_FILE}
 
-
-      - name: Create the the release
+      - name: Create the release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.event.inputs.version }}
           body: "Release for testing purposes only"
-          files: ${{ env.PRIMAZA_CONFIG_FILE }}
+          files: ${{ env.PRIMAZA_CONF${{ env.WORKER_CONFIG_FILE }}
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/scripts/setup.cfg
+++ b/scripts/setup.cfg
@@ -34,3 +34,4 @@ where = src
 console_scripts =
     primazactl = primazactl.primazactl:main
     primazatest = primazatest.runtest:main
+    rsakey = primazatest.rsakey:main

--- a/scripts/src/primazactl/primazactl.py
+++ b/scripts/src/primazactl/primazactl.py
@@ -1,96 +1,206 @@
 import argparse
 import os
+import re
 import semver
+import traceback
 from pathlib import Path
 from primazactl.primazamain import primazamain
+from primazactl.primazaworker import primazaworker
+from primazactl.utils import logger
+
+PRIMAZA_MAIN = "main"
+PRIMAZA_WORKER = "worker"
+
+
+def kubernetes_name(name_input):
+    pattern = re.compile("^(([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9]).)*"
+                         "([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])$")
+    if not pattern.match(name_input):
+        print("\n[ERROR] value must consist of lower case alphanumeric "
+              "characters, \'-\' or \'.\', and must start and end with "
+              "an alphanumeric character\n")
+        raise ValueError
+    return name_input
 
 
 def main():
 
     parser = argparse.ArgumentParser(
         prog='primazactl',
-        description='Configure and install primaza and primaza worker \
-                    on clusters',
-        epilog="Brought to you by the RedHat app-services team.")
+        description=f'Configure and install primaza {PRIMAZA_MAIN} and '
+                    f'{PRIMAZA_WORKER} on clusters')
+
     parser.add_argument("action", type=str,
                         choices=["install", "info", "uninstall", "join"],
                         help='type of action to perform.')
     parser.add_argument('install_type', type=str,
-                        choices=["main", "worker"],
-                        help='specify primaza or worker.')
+                        choices=[PRIMAZA_MAIN, PRIMAZA_WORKER],
+                        help=f'specify {PRIMAZA_MAIN} or {PRIMAZA_WORKER}.')
     parser.add_argument("-c", "--clustername",
-                        dest="cluster_name", type=str, required=False,
-                        help="name of cluster, as it appears in kubeconfig, \
-                             on which to install primaza or worker, default: \
-                             current kubeconfig context")
+                        dest="cluster_name", type=kubernetes_name,
+                        required=False,
+                        help=f"name of cluster, as it appears in kubeconfig, "
+                             f"on which to install {PRIMAZA_MAIN} or "
+                             f"{PRIMAZA_WORKER}, default: current "
+                             f"kubeconfig context")
+    parser.add_argument("-d", "--clusterevironmentname",
+                        dest="cluster_environment_name", type=kubernetes_name,
+                        required=False,
+                        help="name to use for the ClusterEnvironment that "
+                             "will be created in Primaza. Required for "
+                             f"{PRIMAZA_WORKER} install.")
+    parser.add_argument("-e", "--environment",
+                        dest="environment", type=kubernetes_name,
+                        required=False,
+                        help="the Environment that will be associated to "
+                             "the ClusterEnvironment. Required for "
+                             f"{PRIMAZA_WORKER} install.")
+    parser.add_argument("-f", "--config",
+                        dest="primaza_config", type=argparse.FileType('r'),
+                        required=False,
+                        help=f"primaza {PRIMAZA_MAIN} or {PRIMAZA_WORKER}"
+                             f" config file. Takes precedence over --version")
     parser.add_argument("-k", "--kubeconfig",
-                        dest="kubeconfig", type=str, required=False,
+                        dest="kubeconfig", type=argparse.FileType('r'),
+                        required=False,
                         help=f"path to kubeconfig file, default: KUBECONFIG \
                                environment variable if set, otherwise \
-                               {(os.path.join(Path.home(),'.kube','config'))}")
-    parser.add_argument("-f", "--config",
-                        dest="primaza_config", type=str, required=False,
-                        help="primaza config file. Takes precedence \
-                        over --version")
+                               {os.path.join(Path.home(),'.kube','config')}")
+    parser.add_argument("-l", f"--{PRIMAZA_MAIN}kubeconfig",
+                        dest="main_kubeconfig", type=argparse.FileType('r'),
+                        required=False,
+                        help=f"path to kubeconfig file for {PRIMAZA_MAIN}, "
+                             f"default: --kubeconfig if set, KUBECONFIG "
+                             f"environment variable if set, otherwise "
+                             f"{os.path.join(Path.home(),'.kube','config')}."
+                             f" Used for {PRIMAZA_WORKER} install.")
+    parser.add_argument("-m", f"--{PRIMAZA_MAIN}clustername",
+                        dest="main_cluster_name", type=kubernetes_name,
+                        required=False,
+                        help=f"name of cluster, as it appears in kubeconfig,"
+                             f" on which {PRIMAZA_MAIN} is installed. "
+                             f"Defaults to {PRIMAZA_WORKER} install cluster.")
+    parser.add_argument("-p", "--privatekey",
+                        dest="private_key", type=argparse.FileType('r'),
+                        required=False,
+                        help=f"primaza {PRIMAZA_MAIN} private key file. "
+                             f"Required for {PRIMAZA_WORKER} install")
+    parser.add_argument("-n", "--namespace",
+                        dest="namespace", type=kubernetes_name,
+                        required=False,
+                        help="namespace to use for install. Default: "
+                             "primaza_system")
     parser.add_argument("-v", "--version",
                         dest="primaza_version", type=str, required=False,
-                        help="Version of primaza to use, default: newest \
-                              release available. Ignored if --config is set.")
+                        help=f"Version of primaza {PRIMAZA_MAIN} or "
+                             f"{PRIMAZA_WORKER} to use, default: newest "
+                             "release available. Ignored if --config "
+                             "is set.")
+    parser.add_argument("-x", "--verbose", required=False,
+                        action=argparse.BooleanOptionalAction,
+                        help="Set for verbose output")
 
     args = parser.parse_args()
 
-    cluster_name = args.cluster_name
+    if args.verbose:
+        logger.set_verbose(True)
 
-    kube_config = args.kubeconfig
-    if not kube_config:
+    cluster_name = args.cluster_name
+    main_cluster_name = args.main_cluster_name
+    if not main_cluster_name:
+        main_cluster_name = cluster_name
+
+    if not args.kubeconfig:
         kube_config = os.environ.get("KUBECONFIG")
         if not kube_config:
             kube_config = str(os.path.join(Path.home(), ".kube", "config"))
+    else:
+        kube_config = args.kubeconfig.name
 
-    if not os.path.isfile(kube_config):
-        parser.error("\n[ERROR] --kubeconfig does not specify a valid file: "
-                     f"{kube_config}\n")
+    main_kubeconfig = kube_config
+    if args.main_kubeconfig:
+        main_kubeconfig = args.main_kubeconfig.name
 
-    primaza_config = args.primaza_config
-    primaza_version = args.primaza_version
-    if primaza_config:
+    private_key = None
+    if args.private_key:
+        private_key = args.private_key.name
+
+    primaza_config = None
+    if args.primaza_config:
+        primaza_config = args.primaza_config.name
         primaza_version = None
-        if args.action == "install" and args.install_type == "main":
-            if not os.path.isfile(primaza_config):
-                parser.error("\n[ERROR] --config does not specify a valid"
-                             f" file: {primaza_config}\n")
+    else:
+        primaza_version = args.primaza_version
+        if primaza_version:
+            if not semver.VersionInfo.isvalid(primaza_version):
 
-    elif primaza_version:
-        if not semver.VersionInfo.isvalid(primaza_version):
-            parser.error("\n[ERROR] --version is not a valid semantic "
-                         f"version: {primaza_version}\n")
-
-    print(f'install_type: {args.install_type}')
-    print(f'primaza_config: {primaza_config}')
-    print(f'primaza version: {primaza_version}')
-    print(f'cluster name: {cluster_name}')
-    print(f'kube config: {kube_config}')
+                parser.error("\n[ERROR] --version is not a valid semantic "
+                             f"version: {primaza_version}\n")
 
     if args.action == "install":
 
-        if args.install_type == "worker":
-            parser.error("Install and configure primaza worker \
-                   is not yet implemented")
-        else:
-            print("Install and configure primaza main is in progress")
+        if args.install_type == PRIMAZA_WORKER:
+            if not private_key \
+                    or not args.environment \
+                    or not args.cluster_environment_name:
+                parser.error("[ERROR] --privatekey, --environment and "
+                             "--cluster-environment are "
+                             f"required for {PRIMAZA_WORKER} install")
+            logger.log_info(f"Install and configure {PRIMAZA_MAIN} "
+                            "is in progress")
             try:
-                pmain = primazamain.PrimazaMain(cluster_name,
-                                                kube_config,
-                                                primaza_config,
-                                                primaza_version)
-                pmain.install_primaza()
-            except Exception as err:
-                if cluster_name:
-                    parser.error("[ERROR] installing main on "
-                                 f"{cluster_name}: {err}")
-                else:
-                    parser.error(f"[ERROR] installing main: {err}")
 
+                primaza_main = primazamain.PrimazaMain(main_cluster_name,
+                                                       main_kubeconfig,
+                                                       None, None,
+                                                       private_key,
+                                                       args.namespace)
+
+                worker = primazaworker.\
+                    PrimazaWorker(primaza_main,
+                                  cluster_name,
+                                  kube_config,
+                                  primaza_config,
+                                  primaza_version,
+                                  args.environment,
+                                  args.cluster_environment_name,
+                                  args.namespace)
+
+                worker.install_worker()
+                logger.log_info(f"Install and configure {PRIMAZA_WORKER} "
+                                f"completed", True)
+            except Exception as err:
+                if args.verbose:
+                    traceback.print_exc()
+                if cluster_name:
+                    parser.error(f"[ERROR] installing primaza "
+                                 f"{PRIMAZA_WORKER} on {cluster_name}: {err}")
+                else:
+                    parser.error(f"[ERROR] installing primaza "
+                                 f"{PRIMAZA_WORKER}: {err}")
+
+        else:
+            logger.log_info(f"Install and configure {PRIMAZA_MAIN} "
+                            f"is in progress")
+            try:
+                primaza_main = primazamain.PrimazaMain(cluster_name,
+                                                       kube_config,
+                                                       primaza_config,
+                                                       primaza_version,
+                                                       private_key,
+                                                       args.namespace)
+                primaza_main.install_primaza()
+                logger.log_info(f"Install and configure {PRIMAZA_MAIN} "
+                                f"completed", True)
+            except Exception as err:
+                if args.verbose:
+                    traceback.print_exc()
+                if cluster_name:
+                    parser.error(f"[ERROR] installing primaza "
+                                 f"{PRIMAZA_MAIN} on {cluster_name}: {err}")
+                else:
+                    parser.error(f"[ERROR] installing primaza "
+                                 f"{PRIMAZA_MAIN}: {err}")
     else:
         parser.error("info, uninstall and join are not yet implemented.")
 

--- a/scripts/src/primazactl/primazamain/primazamain.py
+++ b/scripts/src/primazactl/primazamain/primazamain.py
@@ -1,66 +1,232 @@
-import tempfile
-from primazactl.utils import command
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from primazactl.utils import kubeconfigwrapper
 from primazactl.utils import primazaconfig
+from primazactl.utils import logger
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+import polling2
+import yaml
 
 
 class PrimazaMain(object):
 
-    kube_config_file: str = None
+    kube_config_wrapper: kubeconfigwrapper.KubeConfigWrapper = None
     cluster_name: str = None
     kustomize: str = None
     primaza_config: str = None
     primaza_version: str = None
 
-    def __init__(self, cluster_name: str, kubeconfigfile: str,
-                 config: str, version: str):
-        self.cluster_name = cluster_name
-        self.kube_config_file = kubeconfigfile
-        self.primaza_config = config
-        self.primaza_version = version
+    certificate_private_key: bytes = None
+    certificate: RSAPrivateKey = None
+    primaza_namespace: str = "primaza-system"
 
-    def start(self):
-        self.install_primaza()
+    def __init__(self, cluster_name: str, kubeconfigfile: str,
+                 config_file: str, version: str,
+                 private_key_file: str, namespace: str):
+        self.cluster_name = cluster_name
+        kcw = kubeconfigwrapper.KubeConfigWrapper(cluster_name,
+                                                  kubeconfigfile)
+        self.kube_config_wrapper = kcw.get_kube_config_for_cluster()
+        self.primaza_config = config_file
+        self.primaza_version = version
+        if namespace:
+            self.primaza_namespace = namespace
+        if private_key_file:
+            logger.log_info(f"Read the key file : {private_key_file}")
+            with open(private_key_file, "rb") as key_file:
+                self.certificate = serialization.\
+                    load_pem_private_key(key_file.read(), password=None)
+        else:
+            self.certificate = rsa.generate_private_key(public_exponent=65537,
+                                                        key_size=2048)
+        self.certificate_private_key = self.certificate.private_bytes(
+            format=serialization.PrivateFormat.PKCS8,
+            encoding=serialization.Encoding.PEM,
+            encryption_algorithm=serialization.NoEncryption()).decode("utf-8")
+
+        logger.log_info("Primaza main created for cluster "
+                        f"{self.cluster_name}")
 
     def install_primaza(self):
-
-        img = "primaza-controller:latest"
-
+        logger.log_entry()
         # need an agnostic way to get the kubeconfig - get as a parameter
-        kcw = kubeconfigwrapper.KubeConfigWrapper(self.cluster_name,
-                                                  self.kube_config_file)
-        kcc = kcw.get_kube_config_content()
-        with tempfile.NamedTemporaryFile(
-                prefix=f"kubeconfig-primaza-{self.cluster_name}-") \
-                as t:
-            t.write(kcc.encode("utf-8"))
-            self.__deploy_primaza(t.name, img)
+        if not self.cluster_name:
+            self.cluster_name = self.kube_config_wrapper.get_cluster_name()
+            if not self.cluster_name:
+                raise RuntimeError("\n[ERROR] installing priamza: "
+                                   "no cluster found.")
+            else:
+                logger.log_info("Cluster set to current context: "
+                                f"{self.cluster_name}")
 
-    def __deploy_primaza(self, kubeconfig_path: str, img: str):
+        self.__deploy_primaza()
 
-        # make sure we deploy to the required cluster
-        kc = kubeconfigwrapper.KubeConfigWrapper(self.cluster_name,
-                                                 kubeconfig_path)
-        kc.use_context()
+    def __deploy_primaza(self):
+        logger.log_entry()
 
-        print(f"self.primaza_config = {self.primaza_config}")
-        if self.primaza_config:
-            print(f"self.primaza_config = {self.primaza_config}")
-            out, err = command.Command().setenv("KUBECONFIG", kubeconfig_path)\
-                .run(f"kubectl apply -f {self.primaza_config}")
-        else:
-            config = primazaconfig.PrimazaConfig(self.primaza_version).\
-                      get_config()
-            with tempfile.NamedTemporaryFile(
-                    prefix=f"kubeconfig-primaza-{self.cluster_name}-") \
-                    as t:
-                t.write(config.encode("utf-8"))
-                out, err = command.Command().\
-                    setenv("KUBECONFIG", kubeconfig_path).\
-                    run(f"kubectl apply -f {t.name}")
-
-        print(out)
+        config = primazaconfig.PrimazaConfig("main", self.primaza_config,
+                                             self.primaza_version)
+        err = config.apply(self.kube_config_wrapper)
         if err != 0:
             raise RuntimeError("\n[ERROR] error deploying "
-                               "Primaza's controller into "
+                               "Primaza's main controller into "
                                f"cluster {self.cluster_name} : {err}\n")
+
+    def __create_certificate_signing_request(self):
+        logger.log_entry()
+        # Generate RSA Key and CertificateSignignRequest
+        return x509.CertificateSigningRequestBuilder().subject_name(x509.Name([
+            x509.NameAttribute(NameOID.COUNTRY_NAME, u"US"),
+            x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u""),
+            x509.NameAttribute(NameOID.LOCALITY_NAME, u""),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, u'primaza'),
+            x509.NameAttribute(NameOID.COMMON_NAME, u'primaza'),
+        ])).add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(u"primaza.io")]),
+            critical=False,
+        ).sign(self.certificate, hashes.SHA256())
+
+    def create_certificate_signing_request_pem(self) -> bytes:
+        """
+        Creates the V1CertificateSigningRequest needed for registration on
+        a worker cluster
+        """
+        logger.log_entry()
+
+        c = self.__create_certificate_signing_request()
+        return c.public_bytes(serialization.Encoding.PEM)
+
+    def create_clustercontext_secret(self, secret_name: str, kubeconfig: str):
+        """
+        Creates the Primaza's ClusterContext secret
+        """
+        logger.log_entry(f"Secret name: {secret_name}")
+
+        api_client = self.kube_config_wrapper.get_api_client()
+        corev1 = client.CoreV1Api(api_client)
+        try:
+            corev1.read_namespaced_secret(name=secret_name,
+                                          namespace=self.primaza_namespace)
+            corev1.delete_namespaced_secret(name=secret_name,
+                                            namespace=self.primaza_namespace)
+        except ApiException as e:
+            if e.reason != "Not Found":
+                raise e
+
+        api_response = corev1.list_namespace()
+        for item in api_response.items:
+            print(f"Namesapce: {item.metadata.name} is {item.status.phase}")
+
+        logger.log_info("create secret")
+        secret = client.V1Secret(
+            metadata=client.V1ObjectMeta(name=secret_name),
+            string_data={"kubeconfig": kubeconfig})
+
+        logger.log_info("create_namespaced_secret")
+        corev1.create_namespaced_secret(namespace=self.primaza_namespace,
+                                        body=secret)
+
+    def write_resource(self, resource, kcw=None):
+        logger.log_entry()
+        if not kcw:
+            kcw = self.kube_config_wrapper
+        resource_config = primazaconfig.PrimazaConfig()
+        resource_config.set_content(resource)
+        resource_config.apply(kcw)
+
+    def write_cluster_environment(self,
+                                  cluster_environment_name,
+                                  environment_name,
+                                  secret_name):
+
+        logger.log_entry("kind: ClusterEnvironment, "
+                         f"name: {cluster_environment_name}, "
+                         f"environment_name: {environment_name} "
+                         f"secret_name: {secret_name}")
+
+        resource = {"apiVersion": "primaza.io/v1alpha1",
+                    "kind": "ClusterEnvironment",
+                    "metadata": {
+                        "name": cluster_environment_name,
+                        "namespace": self.primaza_namespace
+                    },
+                    "spec": {
+                        "environmentName": environment_name,
+                        "clusterContextSecret": secret_name
+                    }
+                    }
+        kcw = self.kube_config_wrapper.get_kube_config_for_cluster()
+
+        logger.log_info(f"write cluster environment:\n{yaml.dump(resource)}")
+        self.write_resource(yaml.dump(resource), kcw=kcw)
+
+    def check_state(self, ce_name, state, timeout=60):
+
+        logger.log_entry(f"check state, ce_name: {ce_name}, state:{state}")
+        api_client = self.kube_config_wrapper.get_api_client()
+        cobj = client.CustomObjectsApi(api_client)
+
+        try:
+            polling2.poll(
+                target=lambda: cobj.get_namespaced_custom_object_status(
+                    group="primaza.io",
+                    version="v1alpha1",
+                    namespace="primaza-system",
+                    plural="clusterenvironments",
+                    name=ce_name).get("status", {}).get("state", None),
+                check_success=lambda x: x is not None and x == state,
+                step=5,
+                timeout=timeout)
+        except polling2.TimeoutException:
+            ce_status = cobj.get_namespaced_custom_object_status(
+                group="primaza.io",
+                version="v1alpha1",
+                namespace="primaza-system",
+                plural="clusterenvironments",
+                name=ce_name)
+            logger.log_error("Timed out waiting for cluster environment "
+                             f"{ce_name}. State was {state}")
+            logger.log_error(f"environment: \n{yaml.dump(ce_status)}")
+            raise RuntimeError("[ERROR] Timed out waiting for cluster "
+                               f"environment: {ce_name} state: {state}")
+
+    def check_status_condition(self, ce_name: str, ctype: str, cstatus: str):
+        logger.log_entry(f"check status condition, ce_name: {ce_name},"
+                         f"type: {ctype}, status {cstatus}")
+        api_client = self.kube_config_wrapper.get_api_client()
+        cobj = client.CustomObjectsApi(api_client)
+
+        ce_status = cobj.get_namespaced_custom_object_status(
+            group="primaza.io",
+            version="v1alpha1",
+            namespace="primaza-system",
+            plural="clusterenvironments",
+            name=ce_name)
+        ce_conditions = ce_status.get("status", {}).get("conditions", None)
+        if ce_conditions is None or len(ce_conditions) == 0:
+            logger.log_error("Cluster Environment status conditions are "
+                             "empty or not defined")
+            raise RuntimeError("[ERROR] checking install: Cluster Environment "
+                               "status conditions are empty or not defined")
+
+        logger.log_info(f"\n\nce conditions:\n{ce_conditions}")
+
+        for condition in ce_conditions:
+            if condition["type"] == ctype:
+                if condition["status"] != cstatus:
+                    message = f'Cluster Environment condition type {ctype} ' \
+                              f'does not have expected status: {cstatus}, ' \
+                              f'status was {condition["status"]}'
+                    logger.log_error(message)
+                    raise RuntimeError(f'[ERROR] {message}')
+                return
+
+        message = f'Cluster Environment condition type {ctype} ' \
+                  'was not found'
+        logger.log_error(message)
+        raise RuntimeError(f'[ERROR] {message}')

--- a/scripts/src/primazactl/primazaworker/primazaworker.py
+++ b/scripts/src/primazactl/primazaworker/primazaworker.py
@@ -1,0 +1,274 @@
+import base64
+import time
+import yaml
+from typing import Dict
+from datetime import datetime, timezone, timedelta
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+from primazactl.utils import kubeconfigwrapper
+from primazactl.utils import primazaconfig
+from primazactl.utils import logger
+from primazactl.utils import command
+from primazactl.primazamain import primazamain
+
+
+class PrimazaWorker(object):
+
+    namespace: str = None
+    cluster_name: str = None
+    kube_config_file: str = None
+    kube_config_wrapper: kubeconfigwrapper.KubeConfigWrapper = None
+    config_file: str = None
+    version: str = None
+    environment: str = None
+    cluster_environment: str = None
+    primaza_main: primazamain.PrimazaMain = None
+    certificate: str = None
+
+    def __init__(self, primaza_main: primazamain.PrimazaMain,
+                 cluster_name: str,
+                 kube_config_file: str,
+                 config_file: str,
+                 version: str,
+                 environment: str,
+                 cluster_environment: str,
+                 namespace: str = "primaza-system"):
+        self.cluster_name = cluster_name
+        self.config_file = config_file
+        kcw = kubeconfigwrapper.KubeConfigWrapper(cluster_name,
+                                                  kube_config_file)
+        self.kube_config_wrapper = kcw.get_kube_config_for_cluster()
+        self.version = version
+        self.environment = environment
+        self.cluster_environment = cluster_environment
+        self.namespace = namespace
+        self.primaza_main = primaza_main
+        logger.log_info("PrimazaWorker created for cluster "
+                        f"{self.cluster_name}")
+
+    def create_primaza_user(self, csr_pem: bytes, csr_name, timeout: int = 60):
+
+        logger.log_entry()
+        """
+        Creates a CertificateSigningRequest for user primaza, approves it,
+        and creates the needed roles and role bindings.
+        """
+        api_client = self.kube_config_wrapper.get_api_client()
+
+        logger.log_info("call CertificatesV1Api")
+        certs = client.CertificatesV1Api(api_client)
+
+        # Check if CertificateSigningRequest has yet been created and approved
+        logger.log_info(f"Check if CertificateSigningRequest {csr_name} "
+                        "has already been created and approved")
+        try:
+            s = certs.read_certificate_signing_request_status(name=csr_name)
+            if s == "Approved":
+                logger.log_info(f"cluster '{self.cluster_name}' already has "
+                                "an approved CertificateSigningRequest "
+                                f"'{csr_name}'")
+                return
+        except ApiException as e:
+            if e.reason != "Not Found":
+                raise e
+
+        # Create CertificateSigningRequest
+        logger.log_info(f"Create CertificateSigningRequest: {csr_name}")
+        v1csr = client.V1CertificateSigningRequest(
+            metadata=client.V1ObjectMeta(name=csr_name),
+            spec=client.V1CertificateSigningRequestSpec(
+                signer_name="kubernetes.io/kube-apiserver-client",
+                request=base64.b64encode(csr_pem).decode("utf-8"),
+                expiration_seconds=86400,
+                usages=["client auth"]))
+        certs.create_certificate_signing_request(v1csr)
+
+        # Approve CertificateSigningRequest
+        logger.log_info("Approve CertificateSigningRequest")
+        v1csr = certs.read_certificate_signing_request(name=csr_name)
+        approval_condition = client.V1CertificateSigningRequestCondition(
+            last_update_time=datetime.now(timezone.utc).astimezone(),
+            message='This certificate was approved by primazactl',
+            reason='primazactl worker install',
+            type='Approved',
+            status='True')
+        v1csr.status.conditions = [approval_condition]
+        # Approve CertificateSigningRequest
+        certs.replace_certificate_signing_request_approval(name=csr_name,
+                                                           body=v1csr)
+        logger.log_info("Configure primaza user permissions")
+        # Configure primaza user permissions
+        self.__configure_primaza_user_permissions()
+
+        # Wait for certificate emission
+        logger.log_info("Wait for certificate emission")
+        tend = datetime.now() + timedelta(seconds=timeout)
+        while datetime.now() < tend:
+            v1csr = certs.read_certificate_signing_request(name=csr_name)
+            status = v1csr.status
+            if hasattr(status, 'certificate') \
+                    and status.certificate is not None:
+                logger.log_info(f"CertificateSignignRequest '{csr_name}' "
+                                f"certificate is ready!")
+                self.certificate = status.certificate
+                return
+            logger.log_info(f"CertificateSignignRequest '{csr_name}' "
+                            f"certificate is not ready")
+            time.sleep(5)
+
+        msg = "Timed-out waiting CertificateSignignRequest " \
+              f"'{csr_name}' certificate to become ready"
+        logger.log_error(msg)
+        raise RuntimeError(msg)
+
+    def __configure_primaza_user_permissions(self):
+
+        logger.log_entry()
+        api_client = self.kube_config_wrapper.get_api_client()
+        rbac = client.RbacAuthorizationV1Api(api_client)
+        try:
+            rbac.read_cluster_role_binding(name="primaza-primaza")
+            return
+        except ApiException as e:
+            if e.reason != "Not Found":
+                raise e
+
+        role = client.V1ClusterRole(
+            metadata=client.V1ObjectMeta(name="primaza"),
+            rules=[
+                client.V1PolicyRule(
+                    api_groups=[""],
+                    resources=["pods"],
+                    verbs=["list", "get", "create"]),
+                client.V1PolicyRule(
+                    api_groups=[""],
+                    resources=["secrets"],
+                    verbs=["create"]),
+                client.V1PolicyRule(
+                    api_groups=["primaza.io/v1alpha1"],
+                    resources=["servicebindings"],
+                    verbs=["create"]),
+            ])
+        rbac.create_cluster_role(role)
+
+        role_binding = client.V1ClusterRoleBinding(
+            metadata=client.V1ObjectMeta(name="primaza-primaza"),
+            role_ref=client.V1RoleRef(api_group="rbac.authorization.k8s.io",
+                                      kind="ClusterRole", name="primaza"),
+            subjects=[
+                client.V1Subject(api_group="rbac.authorization.k8s.io",
+                                 kind="User", name="primaza"),
+            ])
+        rbac.create_cluster_role_binding(role_binding)
+
+    def get_csr_kubeconfig(self, certificate_key: str, csr_name: str) -> Dict:
+        """
+        Generates the kubeconfig for the CertificateSignignRequest `csr`.
+        The key used when creating the CSR is also needed.
+        """
+        logger.log_entry(f"csr name: {csr_name}")
+
+        kcw = self.kube_config_wrapper.get_kube_config_for_cluster()
+        kcd = kcw.get_kube_config_content_as_yaml()
+        key_data = base64.b64encode(certificate_key.encode("utf-8")).\
+            decode("utf-8")
+        kcd["contexts"][0]["context"]["user"] = csr_name
+        kcd["users"][0]["name"] = csr_name
+        kcd["users"][0]["user"]["client-key-data"] = key_data
+        kcd["users"][0]["user"]["client-certificate-data"] = self.certificate
+        if self.cluster_name != self.primaza_main.cluster_name:
+            new_url = self.get_updated_server_url()
+            if new_url:
+                kcd["clusters"][0]["cluster"]["server"] = new_url
+
+        logger.log_info(f"csr kubeconfig:\n{yaml.dump(kcd)}")
+
+        return yaml.dump(kcd)
+
+    def get_updated_server_url(self):
+
+        logger.log_entry()
+        cluster = f'{self.cluster_name.replace("kind-","")}'
+        control_plane = f'{cluster}-control-plane'
+        out, err = command.Command().run(f"docker inspect {control_plane}")
+        if err != 0:
+            raise RuntimeError("\n[ERROR] error getting data from docker:"
+                               f"{self.cluster_name}-control-plane : {err}")
+
+        docker_data = yaml.safe_load(out)
+        try:
+            networks = docker_data[0]["NetworkSettings"]["Networks"]
+            ipaddr = networks["kind"]["IPAddress"]
+            logger.log_info(f"new worker url: https://{ipaddr}:6443")
+            return f"https://{ipaddr}:6443"
+        except KeyError:
+            logger.log_info("new worker url not found")
+            return ""
+
+    def install_worker(self):
+
+        logger.log_entry()
+        # need an agnostic way to get the kubeconfig - get as a parameter
+
+        api_client = self.kube_config_wrapper.get_api_client()
+        corev1 = client.CoreV1Api(api_client)
+        api_response = corev1.list_namespace()
+        for item in api_response.items:
+            print(f"Namespace: {item.metadata.name} is {item.status.phase}")
+
+        if not self.cluster_name:
+            self.cluster_name = self.kube_config_wrapper.get_cluster_name()
+            if not self.cluster_name:
+                raise RuntimeError("\n[ERROR] installing priamza: "
+                                   "no cluster found.")
+            else:
+                logger.log_info("Cluster set to current context: "
+                                f"{self.cluster_name}")
+
+        self.__deploy_worker()
+
+        logger.log_info("Create certificate signing request")
+        csr_name = "primaza"
+        p_csr_pem = self.primaza_main.create_certificate_signing_request_pem()
+        self.create_primaza_user(p_csr_pem, csr_name)
+
+        logger.log_info("Create cluster context secret in main")
+        secret_name = f"primaza-{self.cluster_environment}-kubeconfig"
+        cc_kubeconfig = self.get_csr_kubeconfig(
+            self.primaza_main.certificate_private_key, csr_name)
+        self.primaza_main.create_clustercontext_secret(
+            secret_name, cc_kubeconfig)
+
+        logger.log_info("Create cluster environment in main")
+        self.primaza_main.write_cluster_environment(self.cluster_environment,
+                                                    self.environment,
+                                                    secret_name)
+
+        self.primaza_main.check_state(self.cluster_environment,
+                                      "Online")
+        self.primaza_main.check_status_condition(self.cluster_environment,
+                                                 "Online", "True")
+        self.primaza_main.\
+            check_status_condition(self.cluster_environment,
+                                   "ApplicationNamespacePermissionsRequired",
+                                   "False")
+        self.primaza_main.\
+            check_status_condition(self.cluster_environment,
+                                   "ServiceNamespacePermissionsRequired",
+                                   "False")
+
+        logger.log_exit("Worker install complete")
+
+    def __deploy_worker(self):
+
+        logger.log_entry()
+
+        config = primazaconfig.PrimazaConfig("worker",
+                                             self.config_file,
+                                             self.version)
+        logger.log_info("Deploy worker")
+        err = config.apply(self.kube_config_wrapper)
+        if err != 0:
+            raise RuntimeError("\n[ERROR] error deploying "
+                               "Primaza's worker into "
+                               f"cluster {self.cluster_name} : {err}\n")

--- a/scripts/src/primazactl/utils/command.py
+++ b/scripts/src/primazactl/utils/command.py
@@ -1,6 +1,7 @@
 import subprocess
 import time
 import os
+from primazactl.utils import logger
 
 
 class Command(object):
@@ -22,14 +23,14 @@ class Command(object):
             f"Name or value of the environment variable cannot be None:" \
             f" [{key} = {value}]"
         self.env[key] = value
+        logger.log_info(f"command env set: [{key} = {value}]")
         return self
 
     def run(self, cmd, stdin=None):
         # for debugging purposes
-        print(f",---------,-\n| COMMAND : {cmd}\n'---------'-")
+        logger.log_entry(f"COMMAND : {cmd}")
         if stdin is not None:
-            print(f"With stdin: [\n{stdin}\n]\n")
-        output = None
+            logger.log_entry("get input from stdin")
         exit_code = 0
         try:
             if stdin is None:
@@ -44,8 +45,8 @@ class Command(object):
         except subprocess.CalledProcessError as err:
             output = err.output
             exit_code = err.returncode
-            print('ERROR MESSGE:', output)
-            print('ERROR CODE:', exit_code)
+            logger.log_error(f'MESSAGE: {output}')
+            logger.log_error(f'ERROR CODE: {exit_code}')
         return output.decode("utf-8"), exit_code
 
     def run_wait_for_status(self, cmd, status, interval=20, timeout=180):
@@ -58,5 +59,5 @@ class Command(object):
                 return True, cmd_output, exit_code
             time.sleep(interval)
             start += interval
-        print("ERROR: Time out while waiting for status message.")
+        logger.log_error("Time out while waiting for status message.")
         return False, cmd_output, exit_code

--- a/scripts/src/primazactl/utils/kubeconfigwrapper.py
+++ b/scripts/src/primazactl/utils/kubeconfigwrapper.py
@@ -1,5 +1,7 @@
 from kubeconfig import KubeConfig
 import yaml
+from kubernetes import client, config
+from primazactl.utils import logger
 
 
 class KubeConfigWrapper(object):
@@ -12,39 +14,102 @@ class KubeConfigWrapper(object):
         self.kube_config_file = kube_config_file
         if not cluster_name:
             self.cluster_name = self.get_context()
+            logger.log_info(f"kcw: Use context cluster: {self.cluster_name}")
         else:
             self.cluster_name = cluster_name
-
-    def get_server_url(self):
-        kube_config_content = self.__get_kube_config_content_as_yaml()
-
-        for cluster in kube_config_content["clusters"]:
-            if cluster["name"] == self.cluster_name:
-                print(f'Found Cluster: {self.cluster_name}, '
-                      f'server: {cluster["cluster"]["server"]}')
-                return cluster["cluster"]["server"]
-        return None
-
-    def set_server_url(self, server_url):
-        config = KubeConfig(self.kube_config_file)
-        config.use_context(f"{self.cluster_name}")
-        config.set_cluster(server=server_url)
+        logger.log_info(f"kcw: cluster: {self.cluster_name}, "
+                        f"file: {self.kube_config_file}")
 
     def use_context(self):
-        config = KubeConfig(self.kube_config_file)
-        config.use_context(f"{self.cluster_name}")
+        logger.log_entry(f"Cluster: {self.cluster_name}, "
+                         f"File : {self.kube_config_file}")
+        if self.kube_config_file:
+            config = KubeConfig(self.kube_config_file)
+            config.use_context(f"{self.cluster_name}")
+        else:
+            config = self.get_kube_config_content_as_yaml()
+            config["current-context"] = self.cluster_name
 
     def get_context(self):
-        config = KubeConfig(self.kube_config_file)
-        return config.current_context()
+        if self.kube_config_file:
+            config = KubeConfig(self.kube_config_file)
+            return config.current_context()
+        else:
+            config = self.get_kube_config_content_as_yaml()
+            return config["current-context"]
 
-    def __get_kube_config_content_as_yaml(self):
+    def get_kube_config_content_as_yaml(self):
         if not self.kube_config_content:
-            with open(str(self.kube_config_file), "r") as kc_file:
-                self.kube_config_content = yaml.safe_load(kc_file)
-        return self.kube_config_content
+            self.get_kube_config_content()
+        return yaml.safe_load(self.kube_config_content)
 
     def get_kube_config_content(self):
-        with open(str(self.kube_config_file), "r") as kc_file:
-            return kc_file.read()
-        return ""
+        if not self.kube_config_content:
+            with open(str(self.kube_config_file), "r") as kc_file:
+                self.kube_config_content = kc_file.read()
+        return self.kube_config_content
+
+    def get_kubeconfig_for_content(self, content):
+        kcw = KubeConfigWrapper(self.cluster_name, None)
+        kcw.kube_config_content = content
+        return kcw
+
+    def get_kube_config_for_cluster(self):
+        logger.log_entry(f"Cluster: {self.cluster_name}, "
+                         f"File : {self.kube_config_file}")
+
+        kcc_yaml = self.get_kube_config_content_as_yaml()
+
+        cluster_config = {"apiVersion": "v1",
+                          "kind": kcc_yaml["kind"],
+                          "preferences": kcc_yaml["preferences"],
+                          "current-context": self.cluster_name}
+
+        logger.log_info("look through clusters")
+        for cluster in kcc_yaml["clusters"]:
+            if cluster["name"] == self.cluster_name:
+                logger.log_info(f"cluster found: {self.cluster_name}")
+                cluster_config["clusters"] = [cluster]
+                break
+
+        logger.log_info("look through users")
+        for user in kcc_yaml["users"]:
+            if user["name"] == self.cluster_name:
+                logger.log_info(f"user found: {self.cluster_name}")
+                cluster_config["users"] = [user]
+                break
+
+        logger.log_info("look through contexts")
+        for context in kcc_yaml["contexts"]:
+            if context["name"] == self.cluster_name:
+                cluster_config["contexts"] = [context]
+                logger.log_info(f"context found: {self.cluster_name}")
+                break
+
+        kcw = KubeConfigWrapper(self.cluster_name, None)
+        kcw.kube_config_content = yaml.dump(cluster_config)
+        logger.log_info(f"Kubeconfig:\n{kcw.kube_config_content}")
+        return kcw
+
+    def copy_to_temp_file(self, temp_file):
+        logger.log_entry(f"Cluster: {self.cluster_name}, "
+                         f"File : {temp_file}")
+        temp_file.write(self.get_kube_config_content().encode("utf-8"))
+        return KubeConfigWrapper(self.cluster_name, temp_file.name)
+
+    def get_kube_config_file(self):
+        return self.kube_config_file
+
+    def get_cluster_name(self):
+        return self.cluster_name
+
+    def get_api_client(self) -> client:
+        if self.kube_config_file:
+            self.use_context()
+            config.load_kube_config(config_file=self.kube_config_file)
+            return client.ApiClient()
+        else:
+            content = yaml.safe_load(self.get_kube_config_content())
+            cluster_only_api_client = \
+                config.new_client_from_config_dict(content)
+            return cluster_only_api_client

--- a/scripts/src/primazactl/utils/logger.py
+++ b/scripts/src/primazactl/utils/logger.py
@@ -1,0 +1,44 @@
+import inspect
+
+verbose = False
+
+
+def log_info(message, always=False):
+    if always:
+        print(f"{message}")
+    elif verbose:
+        __write_log("[INFO]", message)
+
+
+def log_entry(message="Just entering"):
+    if verbose:
+        __write_log("[ENTER]", message)
+
+
+def log_exit(message="Just exiting"):
+    if verbose:
+        __write_log("[EXIT] ", message)
+
+
+def log_error(message):
+    if verbose:
+        __write_log("[ERROR]", message)
+    else:
+        print(f"[ERROR] {message}")
+
+
+def set_verbose(value):
+    global verbose
+    verbose = value
+
+
+def __write_log(type, message):
+    stack = inspect.stack()
+    if "self" in stack[2][0].f_locals:
+        calling_class = stack[2][0].f_locals["self"].__class__.__name__
+        calling_method = stack[2][0].f_code.co_name
+        print(f"{type} {calling_class}.{calling_method} : {message}")
+    else:
+        calling_file = stack[1].filename
+        calling_method = stack[1].function
+        print(f"{type} {calling_file}:{calling_method} : {message}")

--- a/scripts/src/primazactl/utils/primazaconfig.py
+++ b/scripts/src/primazactl/utils/primazaconfig.py
@@ -1,17 +1,34 @@
 from github import Github
 import semver
 import requests
+import tempfile
+from primazactl.utils import command
+from primazactl.utils import kubeconfigwrapper
+from primazactl.utils import logger
 
 
 class PrimazaConfig(object):
 
     version: str = None
     repository = "primaza/primazactl"
+    config_file: str = None
+    config_content: str = None
+    type: str = None
 
-    def __init__(self, version=None):
+    def __init__(self, type="main", config_file=None, version=None):
         self.version = version
+        self.config_file = config_file
+        self.type = type
+        logger.log_info(f"Created - type:{type}, "
+                        f"file:{config_file}, "
+                        f"version:{version}")
 
-    def get_config(self):
+    def set_content(self, content):
+        self.config_content = content
+
+    def __set_config_content(self):
+
+        logger.log_entry()
 
         g = Github()
         repo = g.get_repo(self.repository)
@@ -20,33 +37,67 @@ class PrimazaConfig(object):
         latest_release = None
 
         for release in releases:
-            print(f"release found - name: {release.id}")
-            print(f"                tag: {release.tag_name}")
+            logger.log_info(f"release found - name: {release.id}")
+            logger.log_info(f"                tag: {release.tag_name}")
 
             if semver.VersionInfo.isvalid(release.tag_name):
                 if self.version and \
                         semver.compare(self.version, release.tag_name) == 0:
-                    print(f"match found: {release.tag_name}")
-                    return self.__get_config_file(release)
+                    logger.log_info(f"match found: {release.tag_name}")
+                    return self.__get_config_content(release)
                 elif not latest_release or \
                         semver.compare(release.tag_name,
                                        latest_release.tag_name) > 1:
-                    print(f"later match found: {release.tag_name}")
+                    logger.log_info(f"later match found: {release.tag_name}")
                     latest_release = release
 
         if latest_release:
-            return self.__get_config_file(latest_release)
+            return self.__get_config_content(latest_release)
 
-        return ""
+        raise RuntimeError(f"A release was not found in repository "
+                           f"{self.repository} for version {self.version}")
 
-    def __get_config_file(self, release):
+    def __get_config_content(self, release):
 
+        logger.log_entry(f"release = {release}")
+        asset_name = f"primaza_{self.type}_config_{release.tag_name}.yaml"
         for asset in release.get_assets():
-            print("asset found : {asset.name}")
-            if asset.name == f"primaza_config_{release.tag_name}.yaml":
-                print("found required asset:")
-                r = requests.get(asset.browser_download_url)
-                return r.content.decode("utf8")
+            logger.log_info("asset found : {asset.name}")
 
-        raise RuntimeError("A primaza config file was not found for "
+            if asset.name == asset_name:
+                logger.log_info("found required asset:")
+                config = requests.get(asset.browser_download_url)
+                self.config_content = config.encode("utf-8")
+
+        raise RuntimeError(f"A {asset_name} file was not found for "
                            f"version {self.version}")
+
+    def apply(self, kcw: kubeconfigwrapper.KubeConfigWrapper):
+
+        logger.log_entry()
+        prefix = f"kubeconfig-primaza-{kcw.get_cluster_name()}-"
+        with tempfile.NamedTemporaryFile(prefix=prefix) as temp_file:
+
+            # make sure we deploy to the required cluster
+            temp_kcw = kcw.copy_to_temp_file(temp_file)
+            temp_kcw.use_context()
+
+            logger.log_info(f"Using context: {temp_kcw.get_context()}")
+
+            if self.config_file:
+                out, err = command.Command(). \
+                    run("kubectl apply --kubeconfig "
+                        f"{temp_kcw.get_kube_config_file()}"
+                        f" -f {self.config_file}")
+                logger.log_exit(out)
+                return err
+            else:
+                if not self.config_content:
+                    self.__set_config_content()
+
+                out, err = command.Command(). \
+                    run("kubectl apply --kubeconfig "
+                        f"{temp_kcw.get_kube_config_file()}"
+                        f" -f -", self.config_content)
+                logger.log_exit(out)
+                return err

--- a/scripts/src/primazatest/config/kind-main.yaml
+++ b/scripts/src/primazatest/config/kind-main.yaml
@@ -1,6 +1,6 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-name: primazactl-test
+name: primazactl-main-test
 nodes:
   - role: control-plane
     kubeadmConfigPatches:

--- a/scripts/src/primazatest/config/kind-worker.yaml
+++ b/scripts/src/primazatest/config/kind-worker.yaml
@@ -1,0 +1,11 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: primazactl-worker-test
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: "ClusterConfiguration"
+        apiServer:
+          extraArgs:
+            anonymous-auth: "true"

--- a/scripts/src/primazatest/rsakey.py
+++ b/scripts/src/primazatest/rsakey.py
@@ -1,0 +1,41 @@
+import argparse
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+from pathlib import Path
+
+
+def create_key(key_file):
+    certificate = rsa.generate_private_key(public_exponent=65537,
+                                           key_size=2048)
+    certificate_private_key = certificate.private_bytes(
+            format=serialization.PrivateFormat.PKCS8,
+            encoding=serialization.Encoding.PEM,
+            encryption_algorithm=serialization.NoEncryption()).decode("utf-8")
+
+    with open(key_file, "w") as key:
+        key.write(certificate_private_key)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog='rsa_key',
+        description='Create a rsa private key for testing')
+
+    parser.add_argument("key_file", type=str,
+                        help="file to write rsa private key. Must not exist")
+
+    args = parser.parse_args()
+
+    key_file = Path(args.key_file)
+    if key_file.is_file():
+        parser.error("[ERROR] --key_file already exists")
+    key_file_dir = Path(key_file.resolve().parent)
+    key_file_dir.mkdir(parents=True, exist_ok=True)
+
+    create_key(args.key_file)
+
+    print(f"private key file was created: {key_file.resolve()}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
add worker install to primazactl.

Have still to update READMe, add more tests and maybe clean up code a bit.

- To set up test environment:
   - make setup-test
- To install worker for example:
   -  `out/venv3/bin/primazactl install worker -e test -d test-environment -f out/config/worker_config_latest.yaml -c kind-primazactl-worker-test -m kind-primazactl-main-test -p out/keys/primaza_private.key`
   - to get trace output and `-x` flag
- Help:
```
usage: primazactl [-h] [-c CLUSTER_NAME] [-d CLUSTER_ENVIRONMENT_NAME] [-e ENVIRONMENT]
                  [-f PRIMAZA_CONFIG] [-k KUBECONFIG] [-l MAIN_KUBECONFIG]
                  [-m MAIN_CLUSTER_NAME] [-p PRIVATE_KEY] [-n NAMESPACE]
                  [-v PRIMAZA_VERSION] [-x | --verbose | --no-verbose]
                  {install,info,uninstall,join} {main,worker}

Configure and install primaza main and worker on clusters

positional arguments:
  {install,info,uninstall,join}
                        type of action to perform.
  {main,worker}         specify main or worker.

options:
  -h, --help            show this help message and exit
  -c CLUSTER_NAME, --clustername CLUSTER_NAME
                        name of cluster, as it appears in kubeconfig, on which to install
                        main or worker, default: current kubeconfig context
  -d CLUSTER_ENVIRONMENT_NAME, --clusterevironmentname CLUSTER_ENVIRONMENT_NAME
                        name to use for the ClusterEnvironment that will be created in
                        Primaza. Required for worker install.
  -e ENVIRONMENT, --environment ENVIRONMENT
                        the Environment that will be associated to the ClusterEnvironment.
                        Required for worker install.
  -f PRIMAZA_CONFIG, --config PRIMAZA_CONFIG
                        primaza main or worker config file. Takes precedence over --version
  -k KUBECONFIG, --kubeconfig KUBECONFIG
                        path to kubeconfig file, default: KUBECONFIG environment variable if
                        set, otherwise /Users/martinmulholland/.kube/config
  -l MAIN_KUBECONFIG, --mainkubeconfig MAIN_KUBECONFIG
                        path to kubeconfig file for main, default: --kubeconfig if set,
                        KUBECONFIG environment variable if set, otherwise
                        /Users/martinmulholland/.kube/config. Used for worker install.
  -m MAIN_CLUSTER_NAME, --mainclustername MAIN_CLUSTER_NAME
                        name of cluster, as it appears in kubeconfig, on which main is
                        installed. Defaults to worker install cluster.
  -p PRIVATE_KEY, --privatekey PRIVATE_KEY
                        primaza main private key file. Required for worker install
  -n NAMESPACE, --namespace NAMESPACE
                        namespace to use for install. Default: primaza_system
  -v PRIMAZA_VERSION, --version PRIMAZA_VERSION
                        Version of primaza main or worker to use, default: newest release
                        available. Ignored if --config is set.
  -x, --verbose, --no-verbose
                        Set for verbose output
```      