### PR TITLE
Add release single binary workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+on:
+  push:
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Release primazactl
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Deploy releases for Linux
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          architecture: "x64"
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Build binary
+        run: make single-binary
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          prerelease: true
+          files: |
+            ./out/venv3/dist/primazactl

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,20 @@ primazactl: ## Setup virtual environment
 	cd $(SCRIPTS_DIR) && $(PYTHON_VENV_DIR)/bin/pip3 install -r requirements.txt
 	cd $(SCRIPTS_DIR) && $(PYTHON_VENV_DIR)/bin/python3 setup.py install
 
+.PHONY: single-binary
+single-binary: ## Release primazactl as single binary
+	-rm -rf $(PYTHON_VENV_DIR)
+	python3 -m venv $(PYTHON_VENV_DIR)
+	$(PYTHON_VENV_DIR)/bin/pip3 install --upgrade pyinstaller
+	$(PYTHON_VENV_DIR)/bin/pip3 install -r $(SCRIPTS_DIR)/requirements.txt
+	$(PYTHON_VENV_DIR)/bin/pyinstaller \
+		--onefile \
+		--clean \
+		--noconfirm \
+		--distpath $(PYTHON_VENV_DIR)/dist \
+		--workpath $(PYTHON_VENV_DIR)/build \
+		$(SCRIPTS_DIR)/src/primazactl/primazactl.py
+
 .PHONY: lint
 lint: primazactl ## Check python code
 	PYTHON_VENV_DIR=$(PYTHON_VENV_DIR) $(HACK_DIR)/check-python/lint-python-code.sh


### PR DESCRIPTION
Adds a make target for building a single binary and a GitHub Action workflow for creating releases.

To build the single binary the tool [pyinstaller](https://github.com/pyinstaller/pyinstaller) is used.
The workflow is triggered by tag creation and creates a prerelease that have to be manually published.
