### PR TITLE
add checks after namespace install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,42 @@
 # Table of Contents
  - [Introduction](#introduction)
- - [Tool options](#tool-options)
  - [Building the tool ](#building-the-tool)
  - [Running the tool](#running-the-tool)
    - [Pre-reqs](#pre-reqs)
-   - [Command options](#command-options)
-     - [Positional paramters](#positional-parameters)
-     - [Flags](#flags)
+   - [Help](#help)  
+   - [Command summary](#command-summary)
+   - [Main install command](#main-install-command)  
+     - [Help](#main-install-help)
+     - [Options](#main-install-options)
+  - [Worker join command](#worker-join-command)
+     - [Help](#worker-join-help)
+     - [Options](#worker-join-options)
+  - [Worker create application namespace command](#worker-create-application-namespace-command)
+    - [Help](#worker-create-application-namespace-help)
+    - [Options](#worker-create-application-namespace-options)
+  - [Worker create service namespace command](#worker-create-service-namespace-command)
+    - [Help](#worker-create-service-namespace-help)
+    - [Options](#worker-create-service-namespace-options)
  - [Testing](#testing) 
- - [Other useful make targets](#other-useful-make-targets)
+
 
 # Introduction
 
 `primazactl` is a simple Command Line Application for Primaza Administrators.
 
-The first implementation includes primaza main install only and more functions will be added over time.
+The current implementation provides:
+- [main install](#main-install-command) and uninstall.
+- [worker join](#worker-install-command).
+- [worker create service-namespace](#worker-create-service-namespace-command).
+- [worker create application-namespace](#worker-create-application-namespace-command).
 
-# Tool options
-
-```
-usage: primaza [-h] [-f PRIMAZA_CONFIG] [-c CLUSTER_NAME] [-k KUBECONFIG] [-v PRIMAZA_VERSION]
-               {install,info,uninstall,join} {main,worker}
-
-Configure and install primaza and primaza worker on clusters
-
-positional arguments:
-  {install,info,uninstall,join}
-                        type of action to perform.
-  {main,worker}         specify primaza or worker.
-
-options:
-  -h, --help            show this help message and exit
-  -c CLUSTER_NAME, --clustername CLUSTER_NAME
-                        name of cluster, as it appears in kubeconfig, on which to install primaza or worker, default:
-                        current kubeconfig context
-  -k KUBECONFIG, --kubeconfig KUBECONFIG
-                        path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise
-                        <home directory>/.kube/config
-  -f PRIMAZA_CONFIG, --config PRIMAZA_CONFIG
-                        primaza config file. Takes precedence over --version                 
-  -v PRIMAZA_VERSION, --version PRIMAZA_VERSION
-                        Version of primaza to use, default: newest release available. Ignored if --config is set.
-```
 
 # Building the tool
  
 1. Clone this repository
 1. Run: `make primazactl`
 1. Tool will be available in `out/venv3/bin/primazactl`
-1. For example, from repository root directory:
+1. For example, from the repository root directory:
   - `out/venv3/bin/primazactl install main -f primaza-config.yaml`
 
 # Running the tool
@@ -57,85 +45,290 @@ options:
 - python
 - kubectl installed and a kube-apiserver available.
     - see: [kubernetes documentation](https://kubernetes.io/docs/home/)
+- docker    
 - a cluster available for primaza to be installed.
-  - for a kind cluster run `make kind-cluster`.
+  - get a kind cluster by running `make kind-cluster`.
     - default cluster name is primazactl-test.
       - set environment variable `KIND_CLUSTER_NAME` to overwrite.
     - the configuration file used when creating the cluster is `scripts/src/primazatest/config/kind.yaml`. 
       - set environment variable `KIND_CONFIG_FILE` to overwrite.
     - For information on kind see : (kind quick start)[https://kind.sigs.k8s.io/docs/user/quick-start/].
-  
-## Command options:
+- a certificate manager available in the cluster on which primaza main will be installed.
+  - `make kind cluster` installs a certificate manager.
 
-### Positional parameters
-- {install, info, uninstall, join}
-  - The action to perform 
-  - Currently, only install is available.
-  - Others action are illustrations, may change and will currently be ignored.
-- {main, worker}
-  - The primaza entity on which to perform the action.
-  - Currently, only main is available.
-  - worker is an illustration, may change and will currently be ignored.
+## Help
 
-### Flags
-- All flags are optional.
-- `-f`, `--config`
-  - a single file with the configuration information for primaza main install.
-  - to create one based on the main branch of the primaza repository:
-    - `make config`
-      - config file is written to `scripts/config/primaza_config_latest.yaml`
-      - default image is: `quay.io/mmulholl/primaza-main-controllers:latest`
-        - set the environment variable `IMG` to overwrite the image used.
-- `-c`, `--clustername` 
-  - name of cluster on which to install primaza.
-  - will default to the cluster which is the current context of kubeconfig.
-  - note if using kind, prepend `kind-` to the cluster name as provided to kind.
-    - for example for `kind create cluster primaza-test` the cluster specified to primazactl is `kind-primaza-cluster`.
-- `-k`, `--kubeconfig` 
-  - path of kubeconfig file to use.
-    - first default is `KUBECONFIG` environment variable.
-    - second default is `<HOME>/.kube/config`
-- `-v` , `--version`
-    - the version of the image to install.
-    - must be a semantic version.  
-    - will be an alternative to the config file when supported.
-      - once a release is created in this repo which contains a primaza config file named ```primaza_config_{release.tag_name}.yaml```.
-    - not currently available for use.
-    - the future plan is for a default version to be used when neither config or version are provided. 
-  
+Primazactl help is organized in a hierarchy with contextual help available for different commands:
+- `primazactl --help`
+- `primazactl main --help`
+- `primazactl main install --help`
+- `primazactl main uninstall --help`
+- `primazactl worker --help`
+- `primazactl worker join --help`
+- `primazactl worker create --help`
+- `primazactl worker create application-namespace --help`
+- `primazactl worker create service-namespace --help`
+
+## Command Summary
+
+- Main Install
+  - creates the namespace `primaza-system`
+    - control-plane `primaza-controller-manager`
+    - default image installed: `ghcr.io/primaza/primaza:latest`
+  - adds kubernetes resources required by primaza-main  
+- Worker Join
+    - requires main to be installed first.
+    - add kubernetes resources required by primaza-worker
+    - creates an [indentity](docs/identities.md#identities) in the worker namespace which is shared with primaza main.   
+    - creates a cluster-environment resource in main to enable main-worker communication.
+- Worker create application-namespace.
+    - requires worker join to be complete first.
+    - creates a namespace `primaza-application`.
+    - creates an [indentity](docs/identities.md#identities) in the main namespace which is shared with the application namespace.
+        - enables primaza main to access the namespace
+    - creates a service account for the application-namespace to access kubernetes resources.
+    - provides primaza worker service account with access to the namespace
+- Worker create application-service.
+    - requires worker join to be complete first.
+    - creates a namespace `primaza-service`.
+    - creates an [indentity](docs/identities.md#identities) in the main namespace which is shared with the service namespace.
+        - enables primaza main to access the namespace
+    - creates two service accounts for the service-namespace to access kubernetes resources based on two different roles.
+    - provides primaza worker service account with access to the namespace
+    
+## Main install command
+
+### Main install help
+```
+usage: primazactl main install [-h] [-x] [-f CONFIG] [-v VERSION] [-c CLUSTER_NAME] [-k KUBECONFIG] [-n NAMESPACE]
+
+options:
+  -h, --help            show this help message and exit
+  -x, --verbose         Set for verbose output
+  -f CONFIG, --config CONFIG
+                        primaza config file. Takes precedence over --version
+  -v VERSION, --version VERSION
+                        Version of primaza to use. Ignored if --config is set.
+  -c CLUSTER_NAME, --clustername CLUSTER_NAME
+                        name of cluster, as it appears in kubeconfig, on which to install primaza or worker, default: current kubeconfig context
+  -k KUBECONFIG, --kubeconfig KUBECONFIG
+                        path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise <USER-HOME>.kube/config
+  -n NAMESPACE, --namespace NAMESPACE
+                        namespace to use for install. Default: primaza-system
+
+```
+### Main install options
+ - `--config CONFIG`:
+    - CONFIG: the manifest file for installing primaza main
+    - To generate a suitable manifest file:
+      - Run `make config` from the repository
+      - The manifest will be created: `out/config/primaza_config_latest.yaml`
+      - The manifest file sets the namespace to `primaza-system`
+      - The manifest file sets the image to `ghcr.io/primaza/primaza:latest`
+          - Set the environment variable `IMG` before running make to overwrite the image used.
+ - `--clustername CLUSTER_NAME`:
+    - CLUSTER_NAME: the cluster, as it appears in kubeconfig, on which to install primaza main
+    - To create a kind cluster to use for testing:
+        - Run `make kind-cluster` 
+            - The cluster created for main install is `primazactl-main-test`
+            - Set the environment variable `KIND_CLUSTER_MAIN_NAME` before running make to overwrite the name of the cluster created.
+    - If using kind, prepend `kind-` to the cluster name.
+ - `--kubeconfig KUBECONFIG` 
+    - The kubeconfig file is not modified by primazactl.
+    - The cluster specified for main install does not have to be the current context.
+ - `--version VERSION`
+    - Not currently supported.
+        - When supported will provide an alternative to providing a config file.
+ - `--namespace NAMESPACE`  
+   - Not currently supported.
+   - current default is `primaza-system`.
+
+## Worker join command
+
+Notes:
+- requires primaza main installed.
+- the namespace created is named `kube-system`.
+  - Not currently supported to use a different name.
+
+
+### Worker join help
+```
+usage: primazactl worker join [-h] [-x] [-f CONFIG] [-v VERSION] [-c CLUSTER_NAME] [-k KUBECONFIG] -d CLUSTER_ENVIRONMENT -e ENVIRONMENT [-l MAIN_KUBECONFIG] [-m MAIN_CLUSTERNAME]
+
+options:
+  -h, --help            show this help message and exit
+  -x, --verbose         Set for verbose output
+  -f CONFIG, --config CONFIG
+                        primaza config file. Takes precedence over --version
+  -v VERSION, --version VERSION
+                        Version of primaza to use. Ignored if --config is set.
+  -c CLUSTER_NAME, --clustername CLUSTER_NAME
+                        name of cluster, as it appears in kubeconfig, on which to install primaza or worker, default: current kubeconfig context
+  -k KUBECONFIG, --kubeconfig KUBECONFIG
+                        path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise /Users/martinmulholland/.kube/config
+  -d CLUSTER_ENVIRONMENT, --clusterenvironment CLUSTER_ENVIRONMENT
+                        name to use for the ClusterEnvironment that will be created in Primaza
+  -e ENVIRONMENT, --environment ENVIRONMENT
+                        the Environment that will be associated to the ClusterEnvironment
+  -l MAIN_KUBECONFIG, --primaza-kubeconfig MAIN_KUBECONFIG
+                        path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise /Users/martinmulholland/.kube/config
+  -m MAIN_CLUSTERNAME, --primaza-clustername MAIN_CLUSTERNAME
+                        name of cluster, as it appears in kubeconfig, on which Primaza is installed. Default: current kubeconfig context
+```
+### Worker join options
+- `--config CONFIG`:
+    - CONFIG contains the manifest file for the primaza worker.
+    - To generate a suitable manifest file:
+        - Run `make config` from the repository
+        - The manifest will be created: `out/config/worker_config_latest.yaml` 
+- `--clustername CLUSTER_NAME` 
+    - CLUSTER_NAME: the cluster, as it appears in kubeconfig, on which to add primaza-worker
+    - To create a kind cluster to use for testing:
+        - Run `make kind-cluster`
+            - The cluster created for the worker is `primazactl-worker-test`
+            - Set the environment variable `KIND_CLUSTER_WORKER_NAME` before running make to overwrite the name of the cluster created.
+    - If using kind, prepend `kind-` to the cluster name.
+    - Can use the same cluster as used for main install.
+- `--kubeconfig KUBECONFIG`
+    - The kubeconfig file is not modified by primazactl.
+    - The cluster specified for worker join does not have to be the current context.
+- `--version VERSION`
+    - Not currently supported.
+        - When supported will provide an alternative to providing a config file.
+- `--clusterenvironment CLUSTER_ENVIRONMENT`
+    - name to be used for the cluster environment resource created in the primaza-main namespace.
+- `--environment ENVIRONMENT`
+    - the name that will be associated to the ClusterEnvironment,
+- `--primaza-kubeconfig MAIN_KUBECONFIG`
+    - only set if the cluster on which primaza main installed is in a different kubeconfig file from the one set using the `--kubeconfig` option.
+- `--primaza-clustername MAIN_CLUSTERNAME`
+    - only set if cluster on which primaza main is installed is different from the one set using the `--clustername` option.
+
+## Worker create application namespace command
+
+Notes:
+- requires primaza worker join to be completed.
+- namespace created will be `primaza-application`
+  - Not currently supported to use a different name.
+
+### Worker create application-namespace help
+```
+usage: primazactl worker create application-namespace [-h] [-x] -d CLUSTER_ENVIRONMENT [-c CLUSTER_NAME] [-m MAIN_CLUSTERNAME] [-f CONFIG]
+
+options:
+  -h, --help            show this help message and exit
+  -x, --verbose         Set for verbose output
+  -d CLUSTER_ENVIRONMENT, --clusterenvironment CLUSTER_ENVIRONMENT
+                        name to use for the ClusterEnvironment that will be created in Primaza
+  -c CLUSTER_NAME, --clustername CLUSTER_NAME
+                        name of worker cluster, as it appears in kubeconfig, on which to create the namespace, default: current kubeconfig context
+  -m MAIN_CLUSTERNAME, --primaza-clustername MAIN_CLUSTERNAME
+                        name of cluster, as it appears in kubeconfig, on which Primaza is installed. Default: current kubeconfig context
+  -f CONFIG, --config CONFIG
+                        Config file containing agent roles
+```
+
+### Worker create application-namespace options: 
+- `--clustername CLUSTER_NAME`
+    - CLUSTER_NAME: the cluster, as it appears in kubeconfig, on which primaza-worker is installed
+- `--clusterenvironment CLUSTER_ENVIRONMENT`
+    - Used in the name of the primaza main [indentity](docs/identities.md#identities).
+- `--primaza-clustername MAIN_CLUSTERNAME`
+    - Name of cluster, as it appears in kubeconfig, on which Primaza main is installed. Default: current kubeconfig context
+- `--config CONFIG`
+    - Config file containing thr manifests for application agent roles.
+    - To generate a suitable config file:
+        - Run `make config` from the repository
+        - The config will be created: `out/config/application_agent_config_latest.yaml`
+
+
+## Worker create service namespace command
+
+Notes:
+- requires primaza worker join to be completed.
+- namespace created will be `primaza-service`.
+    - Not currently supported to use a different name.  
+    
+### Worker create service-namespace help:
+```
+usage: primazactl worker create service-namespace [-h] [-x] -d CLUSTER_ENVIRONMENT [-c CLUSTER_NAME] [-m MAIN_CLUSTERNAME] [-f CONFIG]
+
+options:
+  -h, --help            show this help message and exit
+  -x, --verbose         Set for verbose output
+  -d CLUSTER_ENVIRONMENT, --clusterenvironment CLUSTER_ENVIRONMENT
+                        name to use for the ClusterEnvironment that will be created in Primaza
+  -c CLUSTER_NAME, --clustername CLUSTER_NAME
+                        name of worker cluster, as it appears in kubeconfig, on which to create the namespace, default: current kubeconfig context
+  -m MAIN_CLUSTERNAME, --primaza-clustername MAIN_CLUSTERNAME
+                        name of cluster, as it appears in kubeconfig, on which Primaza is installed. Default: current kubeconfig context
+  -f CONFIG, --config CONFIG
+                        Config file containing agent roles
+```
+
+### Worker create service-namespace options: 
+- `--clustername CLUSTER_NAME`
+    - CLUSTER_NAME: the cluster, as it appears in kubeconfig, on which primaza-worker is installed
+- `--clusterenvironment CLUSTER_ENVIRONMENT`
+    - Used in the name of the primaza main [indentity](docs/identities.md#identities).
+- `--primaza-clustername MAIN_CLUSTERNAME`
+    - name of cluster, as it appears in kubeconfig, on which Primaza main is installed. Default: current kubeconfig context
+- `--config CONFIG`
+    - Config file containing thr manifests for application agent roles.
+    - To generate a suitable config file:
+        - Run `make config` from the repository
+        - The config will be created: `out/config/service_agent_config_latest.yaml`
+    
+    
 # Testing
 
 - To run the tests run `make test`
-  - This will combine:
+  - This will:
+    - run `make setup-test`
+    - run the test:  `out/venv3/bin/primazatest`
+        - src script is `scripts/src/promazatest/runtest.sh`
+        - requires inputs: python virtual environment directory, the primaza configuration file and the cluster names.
+- To set up the test environment run `make setup-test` 
+  - This will run in order:  
       - `make clean`
+        - deletes:
+          - test clusters, 
+          - generated config files. 
+          - python virtual environment.
       - `kind-cluster`
-        - Create a kind cluster 
-        - default cluster name is primazactl-test
-          - set environment variable `KIND_CLUSTER_NAME` to overwrite.
-        - the configuration file used when creating the cluster is `scripts/src/primazatest/config/kind.yaml`.
-          - set environment variable `KIND_CONFIG_FILE` to overwrite.
-      - `make primazactl`
+        - Creates two kind clusters 
+          - `primazactl-main-test`
+            - used to install primaza main by the tests
+            - set environment variable `KIND_MAIN_CLUSTER_NAME` to overwrite. 
+            - a configuration file is used when creating the cluster 
+               - The file used if `scripts/src/primazatest/config/kind-main.yaml`.
+               - set environment variable `MAIN_KIND_CONFIG_FILE` to overwrite.
+          - `primazactl-worker-test`
+            - used by the tests:
+                - worker join.
+                - worker create application-namespace.
+                - worker create service-namespace.
+            - set environment variable `KIND_WORKER_CLUSTER_NAME` to overwrite.
+            - a configuration file is used when creating the cluster
+                - The file used if `scripts/src/primazatest/config/kind-worker.yaml`.
+                - set environment variable `WORKER_KIND_CONFIG_FILE` to overwrite.
+     - `make primazactl`
         - creates a python virtual environment from which primazactl can be invoked.
         - default directory is `out/venv1`
           - set environment variable `PYTHON_VENV_DIR` to overwrite.
       - `make config`
-        - Creates a primaza configuration file.
+        - Creates primaza configuration files required by pimazactl.
           - clones the primaza repository.
-          - uses kustomize to create a single config file from `config/default`
-          - image is set by default to `quay.io/mmulholla/primaza-main-controllers:latest`
-            - set the environment variable `IMG` overwrite the image used.
-      - runs the test:  `out/venv3/bin/primazatest`
-        - src script is `scripts/src/promazatest/runtest.sh`
-          - requires inputs: python virtual environment directory, the primaza configuration file and the cluster name.
-        
-# Other useful make targets:
-
-  - `lint`
-    - run lint on the python files.
-  - `primaza-main-controllers`
-    - clones the primaza repository and runs 
-      - make primaza docker-build
-      - make primaza docker-push
-      - image is set by default to `quay.io/mmulholla/primaza-main-controllers:latest`
-        - set the environment variable `IMG` overwrite the image used.
-        - to push to `quay.io` you will need to run `docker login quay.io`
+          - uses kustomize to create config files:
+            - `out/config/primaza_config_latest.yaml`
+                - Sets the namespace to `primaza-system`
+                - Sets the image to `ghcr.io/primaza/primaza:latest`
+                    - Set the environment variable `IMG` before running make to overwrite the image used.
+            - `out/config/worker_config_latest.yaml`
+            - `out/config/application_agent_config_latest.yaml`
+               - namespace is set to `primaza-application`
+                   - Set the environment variable `APPLICATION_NAMESPACE` before running make to overwrite the namesapce used.
+            - `out/config/service_agent_config_latest.yaml`
+                - namespace is set to `primaza-service`
+                    - Set the environment variable `SERVICE_NAMESPACE` before running make to overwrite the namesapce used.
+    

--- a/scripts/src/primazactl/cmd/worker/create/namespace.py
+++ b/scripts/src/primazactl/cmd/worker/create/namespace.py
@@ -86,7 +86,7 @@ def __create_namespace(args, type):
             cluster_environment=args.cluster_environment,
         )
 
-        main_user = main.create_primaza_service_account(
+        main_user = main.create_primaza_identity(
             args.cluster_environment)
         kcfg = main.get_kubeconfig(main_user, args.cluster_name)
 
@@ -101,7 +101,10 @@ def __create_namespace(args, type):
 
         secret_name = f"{WORKER_ID}-{args.cluster_environment}"
         worker.create_namespaced_secret(secret_name, kcfg)
-        print(f"{type} namespace was successfully created")
+
+        namespace.check()
+        print(f"{type} namespace primaza-{type} was successfully created")
+
     except Exception:
         print(traceback.format_exc())
         print(f"\nAn exception creating an {type} namespace",

--- a/scripts/src/primazactl/identity/kubeidentity.py
+++ b/scripts/src/primazactl/identity/kubeidentity.py
@@ -8,112 +8,116 @@ from primazactl.kube.serviceaccount import ServiceAccount
 from primazactl.kube.secret import Secret
 
 
-def get_identity_kubeconfig(
-        kubeconfig: KubeConfigWrapper,
-        identity: str,
-        namespace: str,
-        serverUrl: str | None) -> str:
-    """
-        Generates the kubeconfig for the Identity (Service Account) `identity`.
+class KubeIdentity(object):
 
-        :type kubeconfig: KubeConfigWrapper
-        :param kubeconfig: Kubeconfig to use to connect to the cluster
-        :type identity: str
-        :param identity: The name of the identity
-        :type serverUrl: str | None
-        :param serverUrl: Overwrite the generated kubeconfig's server URL
-        :rtype: str
-        :return kubeconfig: The kubeconfig as string
-    """
-    logger.log_entry(f"csr name: {identity}")
+    api_client: client = None
+    identity: str = None
+    namespace: str = None
 
-    api_client = kubeconfig.get_api_client()
-    idauth = get_identity_token(api_client, identity, namespace)
+    def __init__(self, api_client: client, identity: str, namespace: str,):
+        self.api_client = api_client
+        self.identity = identity
+        self.namespace = namespace
 
-    kcw = kubeconfig.get_kube_config_for_cluster()
-    kcd = kcw.get_kube_config_content_as_yaml()
-    kcd["contexts"][0]["context"]["user"] = identity
-    kcd["users"][0]["name"] = identity
-    kcd["users"][0]["user"]["token"] = idauth["token"]
+    def get_kubeconfig(self,
+                       kubeconfig: KubeConfigWrapper,
+                       serverUrl: str | None) -> str:
+        """
+            Generates the kubeconfig for the Identity (Service Account)
+            `identity`.
 
-    if serverUrl is not None:
-        kcd["clusters"][0]["cluster"]["server"] = serverUrl
+            :type kubeconfig: KubeConfigWrapper
+            :param kubeconfig: Kubeconfig to use to connect to the cluster
+            :type identity: str
+            :param identity: The name of the identity
+            :type serverUrl: str | None
+            :param serverUrl: Overwrite the generated kubeconfig's server URL
+            :rtype: str
+            :return kubeconfig: The kubeconfig as string
+        """
+        logger.log_entry(f"csr name: {self.identity}, "
+                         f"namespace: {self.namespace}")
 
-    # logger.log_info(f"kubeconfig:\n{yaml.dump(kcd)}")
+        idauth = self.get_token()
 
-    return yaml.dump(kcd)
+        kcw = kubeconfig.get_kube_config_for_cluster()
+        kcd = kcw.get_kube_config_content_as_yaml()
+        kcd["contexts"][0]["context"]["user"] = self.identity
+        kcd["users"][0]["name"] = self.identity
+        kcd["users"][0]["user"]["token"] = idauth["token"]
 
+        if serverUrl is not None:
+            kcd["clusters"][0]["cluster"]["server"] = serverUrl
 
-def get_identity_token(
-        api_client: client.ApiClient,
-        identity: str,
-        namespace: str,
-        timeout: int = 60) -> Dict[str, str]:
-    """
-        Retrieves the Identity's token: the data in the Service Account's
-        Secret.
+        return yaml.dump(kcd)
 
-        :type kubeconfig: KubeConfigWrapper
-        :param kubeconfig: Kubeconfig to use to connect to the cluster
-        :type identity: str
-        :param identity: The name of the identity
-        :type timeout: int
-        :param timeout: Max time to wait for token to be generated
-        :rtype: Dict[str, str]
-        :return token: A dictionary with Secret data: token, ca.crt,
-                        and namespace
-    """
-    logger.log_entry(f"identity: {identity}")
-    corev1 = client.CoreV1Api(api_client)
+    def get_token(self, timeout: int = 60) -> Dict[str, str]:
+        """
+            Retrieves the Identity's token: the data in the Service Account's
+            Secret.
 
-    secret = polling2.poll(
-        target=lambda: corev1.read_namespaced_secret(
-            name=f"{identity}-key",
-            namespace=namespace),
-        check_success=lambda x:
-        x.data is not None and x.data["token"] is not None,
-        step=1,
-        timeout=timeout,
-    )
-    return secret.data
+            :type kubeconfig: KubeConfigWrapper
+            :param kubeconfig: Kubeconfig to use to connect to the cluster
+            :type identity: str
+            :param identity: The name of the identity
+            :type timeout: int
+            :param timeout: Max time to wait for token to be generated
+            :rtype: Dict[str, str]
+            :return token: A dictionary with Secret data: token, ca.crt,
+                            and namespace
+        """
+        logger.log_entry(f"identity: {self.identity} "
+                         f"namespace: {self.namespace}")
+        corev1 = client.CoreV1Api(self.api_client)
 
+        secret = polling2.poll(
+            target=lambda: corev1.read_namespaced_secret(
+                name=f"{self.identity}-key",
+                namespace=self.namespace),
+            check_success=lambda x:
+            x.data is not None and x.data["token"] is not None,
+            step=1,
+            timeout=timeout,
+        )
+        return secret.data
 
-def create_identity(
-        api_client: client.ApiClient,
-        namespace: str,
-        identity: str):
-    """
-        Creates the Identity `identity` in the provided namespace
+    def create(self):
 
-        :type kubeconfig: KubeConfigWrapper
-        :param kubeconfig: Kubeconfig to use to connect to the cluster
-        :type identity: str
-        :param identity: The name of the identity
-        :type namespace: str
-        :param namespace: Namespace where to create the identity
-    """
-    logger.log_entry(f"identity: {identity}")
+        """
+            Creates the Identity `identity` in the provided namespace
 
-    service_account = ServiceAccount(api_client,
-                                     identity, namespace)
-    service_account.create()
-    sa = service_account.read()
+            :type kubeconfig: KubeConfigWrapper
+            :param kubeconfig: Kubeconfig to use to connect to the cluster
+            :type identity: str
+            :param identity: The name of the identity
+            :type namespace: str
+            :param namespace: Namespace where to create the identity
+        """
+        logger.log_entry(f"identity: {self.identity} "
+                         f"namespace: {self.namespace}")
 
-    ownership = client.V1OwnerReference(
-        api_version=sa.api_version,
-        kind=sa.kind,
-        name=sa.metadata.name,
-        uid=sa.metadata.uid)
+        service_account = ServiceAccount(self.api_client,
+                                         self.identity,
+                                         self.namespace)
+        service_account.create()
+        sa = service_account.read()
 
-    id_key = client.V1Secret(
-        metadata=client.V1ObjectMeta(
-            name=f"{identity}-key",
-            namespace=namespace,
-            owner_references=[ownership],
-            annotations={
-                "kubernetes.io/service-account.name": sa.metadata.name,
-            },
-        ),
-        type="kubernetes.io/service-account-token",)
-    secret = Secret(api_client, f"{identity}-key", namespace, None)
-    secret.create(id_key)
+        ownership = client.V1OwnerReference(
+            api_version=sa.api_version,
+            kind=sa.kind,
+            name=sa.metadata.name,
+            uid=sa.metadata.uid)
+
+        id_key = client.V1Secret(
+            metadata=client.V1ObjectMeta(
+                name=f"{self.identity}-key",
+                namespace=self.namespace,
+                owner_references=[ownership],
+                annotations={
+                    "kubernetes.io/service-account.name": sa.metadata.name,
+                },
+            ),
+            type="kubernetes.io/service-account-token",)
+        secret = Secret(self.api_client, f"{self.identity}-key",
+                        self.namespace, None)
+        secret.create(id_key)

--- a/scripts/src/primazactl/kube/access/accessreview.py
+++ b/scripts/src/primazactl/kube/access/accessreview.py
@@ -1,0 +1,147 @@
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+from primazactl.utils import logger
+
+
+class AccessReview(object):
+
+    user: str = None
+    api_client: client
+    full_verbs: [] = None
+    service_account_namespace: str = None
+    access_namespace: str = None
+
+    def __init__(self, api_client: client,
+                 service_account_name: str,
+                 service_account_namespace: str,
+                 access_namespace: str):
+        self.user = f"system:serviceaccount:" \
+                        f"{service_account_namespace}:" \
+                        f"{service_account_name}"
+        self.service_account_namespace = service_account_namespace
+        self.access_namespace = access_namespace
+        self.api_client = api_client
+        self.full_verbs = self.get_full_verbs()
+
+    def split_verbs(self, verbs):
+        if sorted(verbs) == sorted(self.full_verbs):
+            return "*", None
+        can_verbs = []
+        cannot_verbs = []
+        # Based on allowed verbs, determine not allowed verbs
+        for verb in self.full_verbs:
+            if verb in verbs:
+                can_verbs.append(verb)
+            else:
+                cannot_verbs.append(verb)
+        return can_verbs, cannot_verbs
+
+    def check_access(self,
+                     policy: client.V1PolicyRule) -> []:
+
+        logger.log_info(f"User: {self.user}")
+
+        # replace empty fields with None to enable for loops
+        api_groups = policy.api_groups if policy.api_groups \
+            else ["None"]
+        resource_names = policy.resource_names if policy.resource_names \
+            else ["None"]
+
+        can_reviews = []
+        cannot_reviews = []
+
+        for resource in policy.resources:
+            for api_group in api_groups:
+                if api_group == "None":
+                    api_group = None
+                for resource_name in resource_names:
+                    if resource_name == "None":
+                        resource_name = None
+                    can_verbs, cannot_verbs = self.split_verbs(policy.verbs)
+                    can_reviews.extend(self.__get_access_reviews(
+                        can_verbs, resource, resource_name, api_group))
+                    # do not save cannot verbs if a resource name is present.
+                    # this avoids failures a different policy provides general
+                    # access to the resource name.
+                    # e.g: one policy provides create deployments access and
+                    # another provides delete of only specific deployments
+                    if not resource_name and cannot_verbs:
+                        cannot_reviews.extend(self.__get_access_reviews(
+                            cannot_verbs, resource, resource_name, api_group))
+
+        error_messages = []
+        for review in can_reviews:
+            error_message = self.__check_access(review, True)
+            if error_message:
+                error_messages.append(error_message)
+        for review in cannot_reviews:
+            error_message = self.__check_access(review, False)
+            if error_message:
+                error_messages.append(error_message)
+
+        logger.log_info(f"Errors: {error_messages}")
+
+        return error_messages
+
+    def __get_access_reviews(self, verbs: [], resource: str,
+                             resource_name: str, group: str):
+
+        accesses = []
+        for verb in verbs:
+            accesses.append(
+                client.V1SubjectAccessReviewSpec(
+                    resource_attributes=client.V1ResourceAttributes(
+                        namespace=self.access_namespace,
+                        verb=verb,
+                        resource=resource,
+                        group=group,
+                        name=resource_name,
+                    ),
+                    user=self.user,
+                )
+            )
+        return accesses
+
+    def __check_access(self, access_review, expect_access):
+
+        status = self.check_user_access(access_review)
+        attributes = access_review.resource_attributes
+        msg = f"access: {status.allowed}, " \
+              f"namespace: {attributes.namespace}, " \
+              f"verb: {attributes.verb}, " \
+              f"resource: {attributes.resource}, " \
+              f"name: {attributes.name}"
+
+        if status.allowed == expect_access:
+            logger.log_info(f" PASS: {msg}")
+            return None
+        else:
+            logger.log_error(f"  FAIL: {msg} ")
+            return f"[ERROR]: {self.user} access error: {msg}"
+
+    def get_full_verbs(self):
+        api_instance = client.AdmissionregistrationV1Api(self.api_client)
+        try:
+            api_resources = api_instance.get_api_resources()
+            return api_resources.resources[0].verbs
+        except ApiException as e:
+            logger.log_error("Exception when calling "
+                             "get_api_resources: %s\n" % e)
+            raise e
+
+    def check_user_access(self, access_review: client.V1SubjectAccessReview) \
+            -> client.V1SubjectAccessReviewStatus:
+
+        try:
+            authv1 = client.AuthorizationV1Api(self.api_client)
+            body = client.V1SubjectAccessReview(
+                spec=access_review
+            )
+            response = authv1.create_subject_access_review(body)
+            return response.status
+        except ApiException as e:
+            if e.reason != "Not Found":
+                logger.log_error("Exception when calling "
+                                 "create_subject_access_review: "
+                                 "%s\n" % e)
+                raise e

--- a/scripts/src/primazactl/kube/role.py
+++ b/scripts/src/primazactl/kube/role.py
@@ -55,3 +55,10 @@ class Role(object):
                 logger.log_error("Exception when calling "
                                  "delete_cluster_role: %s\n" % e)
                 raise e
+
+    def get_rules(self):
+        logger.log_entry(f"User: {self.name}")
+        policy = self.read()
+        if policy:
+            return policy.rules
+        return None

--- a/scripts/src/primazactl/kube/serviceaccount.py
+++ b/scripts/src/primazactl/kube/serviceaccount.py
@@ -38,7 +38,6 @@ class ServiceAccount(object):
             try:
                 self.corev1.create_namespaced_service_account(
                     self.namespace, sa)
-                logger.log_info(self.read())
             except ApiException as e:
                 logger.log_error("Exception when calling "
                                  "create_namespaced_service_account: %s\n" % e)
@@ -69,25 +68,6 @@ class ServiceAccount(object):
             self.corev1.delete_namespaced_service_account(
                 name=self.identity,
                 namespace=self.namespace)
-        except ApiException as e:
-            if e.reason != "Not Found":
-                logger.log_error("Exception when calling "
-                                 "delete_namespaced_service_account: "
-                                 "%s\n" % e)
-                raise e
-
-    def create_token(self):
-        logger.log_entry(f"Identity: {self.identity}, "
-                         f"namespace: {self.namespace}")
-
-        try:
-            body = client.AuthenticationV1TokenRequest()
-
-            response = self.corev1.create_namespaced_service_account_token(
-                name=self.identity,
-                namespace=self.namespace,
-                body=body)
-            logger.log_info(response)
         except ApiException as e:
             if e.reason != "Not Found":
                 logger.log_error("Exception when calling "

--- a/scripts/src/primazactl/primaza/primazacluster.py
+++ b/scripts/src/primazactl/primaza/primazacluster.py
@@ -2,8 +2,10 @@ import yaml
 from typing import Dict, Tuple
 from primazactl.utils import logger
 from primazactl.utils.command import Command
-from primazactl.identity import kubeidentity
+from primazactl.identity.kubeidentity import KubeIdentity
 from primazactl.kube.secret import Secret
+from primazactl.kube.role import Role
+from primazactl.kube.access.accessreview import AccessReview
 from primazactl.utils import kubeconfig
 from primazactl.utils.kubeconfigwrapper import KubeConfigWrapper
 
@@ -47,25 +49,24 @@ class PrimazaCluster(object):
             logger.log_info("new cluster url not found")
             return ""
 
-    def get_kubeconfig(self, id: str, other_cluster_name) -> Dict:
-        logger.log_entry(f"id: {id}, "
+    def get_kubeconfig(self, identity: KubeIdentity,
+                       other_cluster_name) -> Dict:
+        logger.log_entry(f"id: {identity.identity}, "
                          f"other_cluster_name: {other_cluster_name}")
         server_url = self.get_updated_server_url() \
             if self.cluster_name != other_cluster_name \
             else None
 
-        return kubeidentity.get_identity_kubeconfig(
-            self.kubeconfig,
-            id,
-            self.namespace,
-            server_url)
+        return identity.get_kubeconfig(self.kubeconfig, server_url)
 
-    def create_service_account(self, user: str = None):
+    def create_identity(self, user: str = None) -> KubeIdentity:
         logger.log_entry()
         if user:
             self.user = user
         api_client = self.kubeconfig.get_api_client()
-        kubeidentity.create_identity(api_client, self.namespace, self.user)
+        identity = KubeIdentity(api_client, self.user, self.namespace)
+        identity.create()
+        return identity
 
     def create_namespaced_secret(self, secret_name: str, kubeconfig: str):
         """
@@ -87,3 +88,21 @@ class PrimazaCluster(object):
             f" --kubeconfig {self.kube_config_file}"
             f" --context {self.cluster_name}"
             f" {cmd}")
+
+    def check_service_account_roles(self, service_account_name,
+                                    role_name, role_namespace):
+        logger.log_entry(self.namespace)
+        api_client = self.kubeconfig.get_api_client()
+        ar = AccessReview(api_client,
+                          service_account_name,
+                          self.namespace,
+                          role_namespace)
+        role = Role(api_client,
+                    role_name, role_namespace, None)
+        rules = role.get_rules()
+        error_messages = []
+        for rule in rules:
+            error_message = ar.check_access(rule)
+            if error_message:
+                error_messages.extend(error_message)
+        return error_messages

--- a/scripts/src/primazactl/primazamain/maincluster.py
+++ b/scripts/src/primazactl/primazamain/maincluster.py
@@ -8,6 +8,7 @@ from primazactl.utils.kubeconfigwrapper import KubeConfigWrapper
 from primazactl.primazamain.constants import PRIMAZA_NAMESPACE
 from primazactl.primaza.primazacluster import PrimazaCluster
 from primazactl.cmd.worker.create.constants import APPLICATION, SERVICE
+from primazactl.identity.kubeidentity import KubeIdentity
 
 
 class MainCluster(PrimazaCluster):
@@ -53,16 +54,15 @@ class MainCluster(PrimazaCluster):
                 "error deploying Primaza's controller into "
                 f"cluster {self.cluster_name}")
 
-    def create_primaza_service_account(self, cluster_environment: str,
-                                       type: str = None) -> str:
+    def create_primaza_identity(self, cluster_environment: str,
+                                type: str = None) -> KubeIdentity:
         logger.log_entry(f"type: {type} environment: {cluster_environment}")
         if type == APPLICATION or type == SERVICE:
             sa_name = f"primaza-{type}-{cluster_environment}-sa"
         else:
             sa_name = f"primaza-{cluster_environment}-{self.namespace}-sa"
 
-        self.create_service_account(sa_name)
-        return sa_name
+        return self.create_identity(sa_name)
 
     def write_resource(self, resource, kcw=None):
         logger.log_entry()

--- a/scripts/src/primazactl/primazaworker/workercluster.py
+++ b/scripts/src/primazactl/primazaworker/workercluster.py
@@ -67,11 +67,11 @@ class WorkerCluster(PrimazaCluster):
 
         logger.log_info("Create certificate signing request")
 
-        self.create_service_account()
+        identity = self.create_identity()
 
         logger.log_info("Create cluster context secret in main")
         secret_name = f"primaza-{self.cluster_environment}-kubeconfig"
-        cc_kubeconfig = self.get_kubeconfig(WORKER_ID,
+        cc_kubeconfig = self.get_kubeconfig(identity,
                                             self.primaza_main.cluster_name)
         self.primaza_main.create_namespaced_secret(
             secret_name, cc_kubeconfig)
@@ -106,3 +106,8 @@ class WorkerCluster(PrimazaCluster):
         if err != 0:
             raise RuntimeError("error deploying Primaza's CRDs into "
                                f"cluster {self.cluster_name} : {err}\n")
+
+    def check_worker_roles(self, role_name, role_namespace):
+        return self.check_service_account_roles(self.user,
+                                                role_name,
+                                                role_namespace)

--- a/scripts/src/primazactl/primazaworker/workernamespace.py
+++ b/scripts/src/primazactl/primazaworker/workernamespace.py
@@ -5,6 +5,7 @@ from primazactl.kube.rolebinding import RoleBinding
 from primazactl.kube.roles.primazaroles import get_primaza_namespace_role
 from primazactl.primaza.primazacluster import PrimazaCluster
 from primazactl.primazamain.maincluster import MainCluster
+from primazactl.cmd.worker.create.constants import APPLICATION
 from .workercluster import WorkerCluster
 
 
@@ -12,7 +13,7 @@ class WorkerNamespace(PrimazaCluster):
 
     main_cluster: str = None
     type: str = None
-    kube_namesapce: Namespace = None
+    kube_namespace: Namespace = None
     cluster_environment: str = None
     role_config: str = None
     main: MainCluster = None
@@ -52,12 +53,12 @@ class WorkerNamespace(PrimazaCluster):
         self.kube_namespace.create()
 
         # Request a new service account from primaza main
-        sa_name = self.main.create_primaza_service_account(
+        main_identity = self.main.create_primaza_identity(
             self.cluster_environment,
             self.type)
 
         # Get kubeconfig with secret from service accounf
-        kc = self.main.get_kubeconfig(sa_name, self.cluster_name)
+        kc = self.main.get_kubeconfig(main_identity, self.cluster_name)
 
         # - in the created namespace, create the Secret
         #     'primaza-auth-$CLUSTER_ENVIRONMENT' the Worker key
@@ -93,6 +94,38 @@ class WorkerNamespace(PrimazaCluster):
                                       self.worker.namespace,
                                       self.worker.user)
         primaza_binding.create()
+
+    def check(self):
+
+        error_messages = []
+        if self.type == APPLICATION:
+            error_message = self.check_service_account_roles(
+                "primaza-controller-agentapp",
+                "agentapp-role", self.namespace)
+            if error_message:
+                error_messages.extend(error_message)
+        else:
+            error_message = self.check_service_account_roles(
+                "primaza-controller-agentsvc",
+                "leader-election-role", self.namespace)
+            if error_message:
+                error_messages.extend(error_message)
+
+            error_message = self.check_service_account_roles(
+                "primaza-controller-agentsvc",
+                "manager-role", self.namespace)
+            if error_message:
+                error_messages.extend(error_message)
+
+        role = f"{self.worker.user}-{self.type}-role"
+        error_message = self.worker.check_worker_roles(role, self.namespace)
+        if error_message:
+            error_messages.extend(error_message)
+
+        if error_messages:
+            raise RuntimeError(
+                "Error: namespace install has failed to created the correct "
+                f"accesses. Error messages were: {error_messages}")
 
     def install_roles(self):
         logger.log_entry(f"config: {self.role_config}")

--- a/scripts/src/primazatest/runtest.py
+++ b/scripts/src/primazatest/runtest.py
@@ -213,7 +213,7 @@ def test_application_namespace_create(venv_dir, worker_cluster,
         print(f"[{FAIL}] Unexpected error response: {err}")
         return False
 
-    if "application namespace was successfully created" not in out:
+    if "was successfully created" not in out:
         print(f"[{FAIL}] Unexpected response: {out}")
         return False
 
@@ -236,11 +236,11 @@ def test_service_namespace_create(venv_dir, worker_cluster,
         print(f"[{FAIL}] Unexpected error response: {err}")
         return False
 
-    if "service namespace was successfully created" not in out:
+    if "was successfully created" not in out:
         print(f"[{FAIL}] Unexpected response: {out}")
         return False
 
-    print(f"[{PASS}] Application namespace created\n\n{out}")
+    print(f"[{PASS}] Service namespace created\n\n{out}")
     return True
 
 


### PR DESCRIPTION
Have added checks that service accounts have the right access:
- worker service account
- application service account
- service service accounts

The code reads the roles of the service account and then checks all verbs for access to resources can be done by the service account. Also check any verbs not specified cannot de done.

The service account names are currently hard coded in the checks but in the future could be read from the manifests - better done when the dependencies on kubectl are removed.

Also changed the identity code to be an object consistent with the rest of the code and make the calling code better (in my opinion)  

add readme updates.