### PR TITLE
bump cryptography to v40.0.2

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,7 +2,7 @@ requests==2.27.1
 polling2==0.5.0
 PyYAML==6.0
 semver==2.13.0
-cryptography==39.0.0
+cryptography==40.0.2
 kubernetes==25.3.0
 kubeconfig==1.1.1
 PyGithub==1.55


### PR DESCRIPTION
This fixes some security issues identified in v39.0.0 that might affect us.