### PR TITLE
Rename cli parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The current implementation provides:
 - a cluster available for primaza to be installed.
   - get a kind cluster by running `make kind-cluster`.
     - default cluster name is primazactl-test.
-      - set environment variable `KIND_CLUSTER_NAME` to overwrite.
+      - set environment variable `KIND_CONTEXT` to overwrite.
     - the configuration file used when creating the cluster is `scripts/src/primazatest/config/kind.yaml`. 
       - set environment variable `KIND_CONFIG_FILE` to overwrite.
     - For information on kind see : (kind quick start)[https://kind.sigs.k8s.io/docs/user/quick-start/].
@@ -100,7 +100,7 @@ Primazactl help is organized in a hierarchy with contextual help available for d
 
 ### Main install help
 ```
-usage: primazactl main install [-h] [-x] [-f CONFIG] [-v VERSION] [-c CLUSTER_NAME] [-k KUBECONFIG] [-n NAMESPACE]
+usage: primazactl main install [-h] [-x] [-f CONFIG] [-v VERSION] [-c CONTEXT] [-k KUBECONFIG] [-n NAMESPACE]
 
 options:
   -h, --help            show this help message and exit
@@ -109,7 +109,7 @@ options:
                         primaza config file. Takes precedence over --version
   -v VERSION, --version VERSION
                         Version of primaza to use. Ignored if --config is set.
-  -c CLUSTER_NAME, --clustername CLUSTER_NAME
+  -c CONTEXT, --context CONTEXT
                         name of cluster, as it appears in kubeconfig, on which to install primaza or worker, default: current kubeconfig context
   -k KUBECONFIG, --kubeconfig KUBECONFIG
                         path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise <USER-HOME>.kube/config
@@ -126,8 +126,8 @@ options:
       - The manifest file sets the namespace to `primaza-system`
       - The manifest file sets the image to `ghcr.io/primaza/primaza:latest`
           - Set the environment variable `IMG` before running make to overwrite the image used.
- - `--clustername CLUSTER_NAME`:
-    - CLUSTER_NAME: the cluster, as it appears in kubeconfig, on which to install primaza main
+ - `--context CONTEXT`:
+    - CONTEXT: the cluster, as it appears in kubeconfig, on which to install primaza main
     - To create a kind cluster to use for testing:
         - Run `make kind-cluster` 
             - The cluster created for main install is `primazactl-main-test`
@@ -154,7 +154,7 @@ Notes:
 
 ### Worker join help
 ```
-usage: primazactl worker join [-h] [-x] [-f CONFIG] [-v VERSION] [-c CLUSTER_NAME] [-k KUBECONFIG] -d CLUSTER_ENVIRONMENT -e ENVIRONMENT [-l MAIN_KUBECONFIG] [-m MAIN_CLUSTERNAME]
+usage: primazactl worker join [-h] [-x] [-f CONFIG] [-v VERSION] [-c CONTEXT] [-k KUBECONFIG] -d CLUSTER_ENVIRONMENT -e ENVIRONMENT [-l MAIN_KUBECONFIG] [-m TENANT_CONTEXT]
 
 options:
   -h, --help            show this help message and exit
@@ -163,17 +163,17 @@ options:
                         primaza config file. Takes precedence over --version
   -v VERSION, --version VERSION
                         Version of primaza to use. Ignored if --config is set.
-  -c CLUSTER_NAME, --clustername CLUSTER_NAME
+  -c CONTEXT, --context CONTEXT
                         name of cluster, as it appears in kubeconfig, on which to install primaza or worker, default: current kubeconfig context
   -k KUBECONFIG, --kubeconfig KUBECONFIG
                         path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise /Users/martinmulholland/.kube/config
-  -d CLUSTER_ENVIRONMENT, --clusterenvironment CLUSTER_ENVIRONMENT
+  -d CLUSTER_ENVIRONMENT, --cluster-environment CLUSTER_ENVIRONMENT
                         name to use for the ClusterEnvironment that will be created in Primaza
   -e ENVIRONMENT, --environment ENVIRONMENT
                         the Environment that will be associated to the ClusterEnvironment
-  -l MAIN_KUBECONFIG, --primaza-kubeconfig MAIN_KUBECONFIG
+  -l MAIN_KUBECONFIG, --tenant-kubeconfig MAIN_KUBECONFIG
                         path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise /Users/martinmulholland/.kube/config
-  -m MAIN_CLUSTERNAME, --primaza-clustername MAIN_CLUSTERNAME
+  -m TENANT_CONTEXT, --tenant-context TENANT_CONTEXT
                         name of cluster, as it appears in kubeconfig, on which Primaza is installed. Default: current kubeconfig context
   -s MAIN_NAMESPACE, --main-namespace MAIN_NAMESPACE
                         namespace to use for join. Default: primaza-system
@@ -184,8 +184,8 @@ options:
     - To generate a suitable manifest file:
         - Run `make config` from the repository
         - The manifest will be created: `out/config/worker_config_latest.yaml` 
-- `--clustername CLUSTER_NAME` 
-    - CLUSTER_NAME: the cluster, as it appears in kubeconfig, on which to add primaza-worker
+- `--context CONTEXT` 
+    - CONTEXT: the cluster, as it appears in kubeconfig, on which to add primaza-worker
     - To create a kind cluster to use for testing:
         - Run `make kind-cluster`
             - The cluster created for the worker is `primazactl-worker-test`
@@ -199,14 +199,14 @@ options:
     - Specify the version of manifests to use.
         - see: [releases](https://github.com/primaza/primazactl/releases) for available versions.
         - Ignored if a config file is set.
-- `--clusterenvironment CLUSTER_ENVIRONMENT`
+- `--cluster-environment CLUSTER_ENVIRONMENT`
     - name to be used for the cluster environment resource created in the primaza-main namespace.
 - `--environment ENVIRONMENT`
     - the name that will be associated to the ClusterEnvironment,
-- `--primaza-kubeconfig MAIN_KUBECONFIG`
+- `--tenant-kubeconfig MAIN_KUBECONFIG`
     - only set if the cluster on which primaza main installed is in a different kubeconfig file from the one set using the `--kubeconfig` option.
-- `--primaza-clustername MAIN_CLUSTERNAME`
-    - only set if cluster on which primaza main is installed is different from the one set using the `--clustername` option.
+- `--tenant-context TENANT_CONTEXT`
+    - only set if cluster on which primaza main is installed is different from the one set using the `--context` option.
 - `--main-namespace MAIN_NAMESPACE`
     - Namespace of primaza-main.
     - Default is `primaza-system`.
@@ -219,16 +219,16 @@ Notes:
 
 ### Worker create application-namespace help
 ```
-usage: primazactl worker create application-namespace [-h] [-x] -d CLUSTER_ENVIRONMENT [-c CLUSTER_NAME] [-m MAIN_CLUSTERNAME] [-f CONFIG]
+usage: primazactl worker create application-namespace [-h] [-x] -d CLUSTER_ENVIRONMENT [-c CONTEXT] [-m TENANT_CONTEXT] [-f CONFIG]
 
 options:
   -h, --help            show this help message and exit
   -x, --verbose         Set for verbose output
-  -d CLUSTER_ENVIRONMENT, --clusterenvironment CLUSTER_ENVIRONMENT
+  -d CLUSTER_ENVIRONMENT, --cluster-environment CLUSTER_ENVIRONMENT
                         name to use for the ClusterEnvironment that will be created in Primaza
-  -c CLUSTER_NAME, --clustername CLUSTER_NAME
+  -c CONTEXT, --context CONTEXT
                         name of worker cluster, as it appears in kubeconfig, on which to create the namespace, default: current kubeconfig context
-  -m MAIN_CLUSTERNAME, --primaza-clustername MAIN_CLUSTERNAME
+  -m TENANT_CONTEXT, --tenant-context TENANT_CONTEXT
                         name of cluster, as it appears in kubeconfig, on which Primaza is installed. Default: current kubeconfig context
   -f CONFIG, --config CONFIG
                         Config file containing agent roles
@@ -241,11 +241,11 @@ options:
 ```
 
 ### Worker create application-namespace options: 
-- `--clustername CLUSTER_NAME`
-    - CLUSTER_NAME: the cluster, as it appears in kubeconfig, on which primaza-worker is installed
-- `--clusterenvironment CLUSTER_ENVIRONMENT`
+- `--context CONTEXT`
+    - CONTEXT: the cluster, as it appears in kubeconfig, on which primaza-worker is installed
+- `--cluster-environment CLUSTER_ENVIRONMENT`
     - Used in the name of the primaza main [indentity](docs/identities.md#identities).
-- `--primaza-clustername MAIN_CLUSTERNAME`
+- `--tenant-context TENANT_CONTEXT`
     - Name of cluster, as it appears in kubeconfig, on which Primaza main is installed. Default: current kubeconfig context
 - `--config CONFIG`
     - Config file containing thr manifests for application agent roles.
@@ -272,16 +272,16 @@ Notes:
     
 ### Worker create service-namespace help:
 ```
-usage: primazactl worker create service-namespace [-h] [-x] -d CLUSTER_ENVIRONMENT [-c CLUSTER_NAME] [-m MAIN_CLUSTERNAME] [-f CONFIG]
+usage: primazactl worker create service-namespace [-h] [-x] -d CLUSTER_ENVIRONMENT [-c CONTEXT] [-m TENANT_CONTEXT] [-f CONFIG]
 
 options:
   -h, --help            show this help message and exit
   -x, --verbose         Set for verbose output
-  -d CLUSTER_ENVIRONMENT, --clusterenvironment CLUSTER_ENVIRONMENT
+  -d CLUSTER_ENVIRONMENT, --cluster-environment CLUSTER_ENVIRONMENT
                         name to use for the ClusterEnvironment that will be created in Primaza
-  -c CLUSTER_NAME, --clustername CLUSTER_NAME
+  -c CONTEXT, --context CONTEXT
                         name of worker cluster, as it appears in kubeconfig, on which to create the namespace, default: current kubeconfig context
-  -m MAIN_CLUSTERNAME, --primaza-clustername MAIN_CLUSTERNAME
+  -m TENANT_CONTEXT, --tenant-context TENANT_CONTEXT
                         name of cluster, as it appears in kubeconfig, on which Primaza is installed. Default: current kubeconfig context
   -f CONFIG, --config CONFIG
                         Config file containing agent roles
@@ -294,11 +294,11 @@ options:
 ```
 
 ### Worker create service-namespace options: 
-- `--clustername CLUSTER_NAME`
-    - CLUSTER_NAME: the cluster, as it appears in kubeconfig, on which primaza-worker is installed
-- `--clusterenvironment CLUSTER_ENVIRONMENT`
+- `--context CONTEXT`
+    - CONTEXT: the cluster, as it appears in kubeconfig, on which primaza-worker is installed
+- `--cluster-environment CLUSTER_ENVIRONMENT`
     - Used in the name of the primaza main [indentity](docs/identities.md#identities).
-- `--primaza-clustername MAIN_CLUSTERNAME`
+- `--tenant-context TENANT_CONTEXT`
     - name of cluster, as it appears in kubeconfig, on which Primaza main is installed. Default: current kubeconfig context
 - `--config CONFIG`
     - Config file containing thr manifests for application agent roles.
@@ -335,7 +335,7 @@ options:
         - Creates two kind clusters 
           - `primazactl-main-test`
             - used to install primaza main by the tests
-            - set environment variable `KIND_MAIN_CLUSTER_NAME` to overwrite. 
+            - set environment variable `KIND_MAIN_CONTEXT` to overwrite. 
             - a configuration file is used when creating the cluster 
                - The file used if `scripts/src/primazatest/config/kind-main.yaml`.
                - set environment variable `MAIN_KIND_CONFIG_FILE` to overwrite.
@@ -344,7 +344,7 @@ options:
                 - worker join.
                 - worker create application-namespace.
                 - worker create service-namespace.
-            - set environment variable `KIND_WORKER_CLUSTER_NAME` to overwrite.
+            - set environment variable `KIND_WORKER_CONTEXT` to overwrite.
             - a configuration file is used when creating the cluster
                 - The file used if `scripts/src/primazatest/config/kind-worker.yaml`.
                 - set environment variable `WORKER_KIND_CONFIG_FILE` to overwrite.

--- a/scripts/src/primazactl/cmd/create/common.py
+++ b/scripts/src/primazactl/cmd/create/common.py
@@ -24,8 +24,8 @@ def add_shared_args(parser: argparse.ArgumentParser):
 
     # main
     parser.add_argument(
-        "-c", "--clustername",
-        dest="cluster_name",
+        "-c", "--context",
+        dest="context",
         type=str,
         required=False,
         help="name of cluster, as it appears in kubeconfig, \

--- a/scripts/src/primazactl/cmd/create/namespace/common.py
+++ b/scripts/src/primazactl/cmd/create/namespace/common.py
@@ -18,7 +18,7 @@ def add_args_namespace(parser: argparse.ArgumentParser, type):
         help="namespace to create")
 
     parser.add_argument(
-        "-d", "--clusterenvironment",
+        "-d", "--cluster-environment",
         dest="cluster_environment",
         type=kubernetes_name,
         required=True,
@@ -26,8 +26,8 @@ def add_args_namespace(parser: argparse.ArgumentParser, type):
                 will be created in Primaza")
 
     parser.add_argument(
-        "-c", "--clustername",
-        dest="cluster_name",
+        "-c", "--context",
+        dest="context",
         type=str,
         required=False,
         help="name of worker cluster, as it appears in kubeconfig, \
@@ -36,8 +36,8 @@ def add_args_namespace(parser: argparse.ArgumentParser, type):
         default=None)
 
     parser.add_argument(
-        "-m", "--primaza-clustername",
-        dest="main_clustername",
+        "-m", "--tenant-context",
+        dest="tenant_context",
         required=False,
         help="name of cluster, as it appears in kubeconfig, \
                 on which Primaza is installed. Default: \
@@ -71,7 +71,7 @@ def add_args_namespace(parser: argparse.ArgumentParser, type):
 def __create_namespace(args, type):
     try:
 
-        main = MainCluster(cluster_name=args.main_clustername,
+        main = MainCluster(context=args.tenant_context,
                            namespace=args.tenant,
                            kubeconfig_path=None,
                            config_file=None,
@@ -79,7 +79,7 @@ def __create_namespace(args, type):
 
         worker = WorkerCluster(
             primaza_main=main,
-            cluster_name=args.cluster_name,
+            context=args.context,
             kubeconfig_file=None,
             config_file=None,
             version=None,
@@ -90,12 +90,12 @@ def __create_namespace(args, type):
 
         main_user = main.create_primaza_identity(
             args.cluster_environment)
-        kcfg = main.get_kubeconfig(main_user, args.cluster_name)
+        kcfg = main.get_kubeconfig(main_user, args.context)
 
         namespace = WorkerNamespace(type,
                                     args.namespace,
                                     args.cluster_environment,
-                                    args.cluster_name,
+                                    args.context,
                                     args.config,
                                     args.version,
                                     main,

--- a/scripts/src/primazactl/cmd/create/tenant/parser.py
+++ b/scripts/src/primazactl/cmd/create/tenant/parser.py
@@ -32,7 +32,7 @@ def create_tenant(args):
     validate(args)
     try:
         MainCluster(
-            args.cluster_name,
+            args.context,
             args.tenant,
             args.kubeconfig,
             args.config,

--- a/scripts/src/primazactl/cmd/delete/tenant/common.py
+++ b/scripts/src/primazactl/cmd/delete/tenant/common.py
@@ -24,8 +24,8 @@ def add_shared_args(parser: argparse.ArgumentParser):
 
     # main
     parser.add_argument(
-        "-c", "--clustername",
-        dest="cluster_name",
+        "-c", "--context",
+        dest="context",
         type=str,
         required=False,
         help="name of cluster, as it appears in kubeconfig, \

--- a/scripts/src/primazactl/cmd/delete/tenant/parser.py
+++ b/scripts/src/primazactl/cmd/delete/tenant/parser.py
@@ -18,7 +18,7 @@ def delete_tenant(args):
     validate(args)
     try:
         MainCluster(
-            args.cluster_name,
+            args.context,
             args.namespace,
             args.kubeconfig,
             args.config,

--- a/scripts/src/primazactl/cmd/join/parser.py
+++ b/scripts/src/primazactl/cmd/join/parser.py
@@ -47,8 +47,8 @@ def add_args_join(parser: argparse.ArgumentParser):
 
     # worker
     parser.add_argument(
-        "-c", "--clustername",
-        dest="cluster_name",
+        "-c", "--context",
+        dest="context",
         type=str,
         required=False,
         help="name of cluster, as it appears in kubeconfig, \
@@ -68,7 +68,7 @@ def add_args_join(parser: argparse.ArgumentParser):
 
     # main
     parser.add_argument(
-        "-d", "--clusterenvironment",
+        "-d", "--cluster-environment",
         dest="cluster_environment",
         type=kubernetes_name,
         required=True,
@@ -84,7 +84,7 @@ def add_args_join(parser: argparse.ArgumentParser):
                 the ClusterEnvironment")
 
     parser.add_argument(
-        "-l", "--primaza-kubeconfig",
+        "-l", "--tenant-kubeconfig",
         dest="main_kubeconfig",
         required=False,
         help=f"path to kubeconfig file, default: KUBECONFIG \
@@ -94,8 +94,8 @@ def add_args_join(parser: argparse.ArgumentParser):
         default=from_env())
 
     parser.add_argument(
-        "-m", "--primaza-clustername",
-        dest="main_clustername",
+        "-m", "--tenant-context",
+        dest="tenant_context",
         required=False,
         help="name of cluster, as it appears in kubeconfig, \
                 on which Primaza is installed. Default: \
@@ -118,7 +118,7 @@ def join_cluster(args):
 
     try:
         main = MainCluster(
-            cluster_name=args.main_clustername,
+            context=args.tenant_context,
             namespace=args.tenant,
             kubeconfig_path=args.main_kubeconfig,
             config_file=None,
@@ -127,7 +127,7 @@ def join_cluster(args):
 
         WorkerCluster(
             primaza_main=main,
-            cluster_name=args.cluster_name,
+            context=args.context,
             kubeconfig_file=args.kubeconfig,
             config_file=args.config,
             version=args.version,

--- a/scripts/src/primazactl/primaza/primazacluster.py
+++ b/scripts/src/primazactl/primaza/primazacluster.py
@@ -14,7 +14,7 @@ from primazactl.utils import names
 class PrimazaCluster(object):
 
     namespace: str = None
-    cluster_name: str = None
+    context: str = None
     user: str = None
     user_type: str = None
     kube_config_file: str = None
@@ -23,13 +23,13 @@ class PrimazaCluster(object):
     cluster_environment: str = None
     tenant: str = None
 
-    def __init__(self, namespace, cluster_name,
+    def __init__(self, namespace, context,
                  user, user_type,
                  kubeconfig_path, config_file,
                  cluster_environment,
                  tenant):
         self.namespace = namespace
-        self.cluster_name = cluster_name
+        self.context = context
         self.user = user
         self.user_type = user_type if user_type else user
         self.config_file = config_file
@@ -40,12 +40,12 @@ class PrimazaCluster(object):
             if kubeconfig_path is not None \
             else kubeconfig.from_env()
 
-        kcw = KubeConfigWrapper(cluster_name, self.kube_config_file)
+        kcw = KubeConfigWrapper(context, self.kube_config_file)
         self.kubeconfig = kcw.get_kube_config_for_cluster()
 
     def get_updated_server_url(self):
         logger.log_entry()
-        cluster = f'{self.cluster_name.replace("kind-","")}'
+        cluster = f'{self.context.replace("kind-","")}'
         control_plane = f'{cluster}-control-plane'
         out, err = Command().run(f"docker inspect {control_plane}")
         if err != 0:
@@ -63,11 +63,11 @@ class PrimazaCluster(object):
             return ""
 
     def get_kubeconfig(self, identity: KubeIdentity,
-                       other_cluster_name) -> Dict:
+                       other_context) -> Dict:
         logger.log_entry(f"id: {identity.sa_name}, "
-                         f"other_cluster_name: {other_cluster_name}")
+                         f"other_context: {other_context}")
         server_url = self.get_updated_server_url() \
-            if self.cluster_name != other_cluster_name \
+            if self.context != other_context \
             else None
 
         return identity.get_kubeconfig(self.kubeconfig, server_url)
@@ -102,7 +102,7 @@ class PrimazaCluster(object):
         return secret_name
 
     def kubeconfig(self) -> KubeConfigWrapper:
-        return KubeConfigWrapper(self.cluster_name, self.kube_config_file)
+        return KubeConfigWrapper(self.context, self.kube_config_file)
 
     def check_service_account_roles(self, service_account_name,
                                     role_name, role_namespace):

--- a/scripts/src/primazactl/primazamain/maincluster.py
+++ b/scripts/src/primazactl/primazamain/maincluster.py
@@ -1,4 +1,3 @@
-
 from primazactl.utils import logger
 from primazactl.utils.kubeconfigwrapper import KubeConfigWrapper
 from .constants import PRIMAZA_USER
@@ -18,7 +17,7 @@ class MainCluster(PrimazaCluster):
 
     def __init__(
             self,
-            cluster_name: str | None,
+            context: str | None,
             namespace: str | None,
             kubeconfig_path: str | None,
             config_file: str | None,
@@ -26,12 +25,12 @@ class MainCluster(PrimazaCluster):
 
         self.kube_config_file = kubeconfig_path
 
-        cluster_name = cluster_name \
-            if cluster_name is not None \
+        context = context \
+            if context is not None \
             else KubeConfigWrapper(None, self.kube_config_file).get_context()
 
         super().__init__(namespace,
-                         cluster_name,
+                         context,
                          PRIMAZA_USER,
                          None,
                          kubeconfig_path,
@@ -44,11 +43,11 @@ class MainCluster(PrimazaCluster):
         self.manifest = Manifest(namespace, config_file,
                                  version, PRIMAZA_CONFIG)
 
-        kcw = KubeConfigWrapper(cluster_name, self.kube_config_file)
+        kcw = KubeConfigWrapper(context, self.kube_config_file)
         self.kubeconfig = kcw.get_kube_config_for_cluster()
 
         logger.log_info("Primaza main created for cluster "
-                        f"{self.cluster_name}")
+                        f"{self.context}")
 
     def install_primaza(self):
         self.install_config(self.manifest)

--- a/scripts/src/primazactl/primazaworker/workernamespace.py
+++ b/scripts/src/primazactl/primazaworker/workernamespace.py
@@ -64,7 +64,7 @@ class WorkerNamespace(PrimazaCluster):
     def create(self):
         logger.log_entry(f"namespace type: {self.type}, "
                          f"cluster environment: {self.cluster_environment}, "
-                         f"worker cluster: {self.worker.cluster_name}")
+                         f"worker cluster: {self.worker.context}")
 
         # On worker cluster
         # - create the namespace
@@ -77,7 +77,7 @@ class WorkerNamespace(PrimazaCluster):
             self.namespace)
 
         # Get kubeconfig with secret from service accounf
-        kc = self.main.get_kubeconfig(main_identity, self.cluster_name)
+        kc = self.main.get_kubeconfig(main_identity, self.context)
 
         # - in the created namespace, create the Secret
         #     'primaza-auth-$CLUSTER_ENVIRONMENT' the Worker key
@@ -121,7 +121,7 @@ class WorkerNamespace(PrimazaCluster):
         logger.log_info(f"ce:{ce.body}")
 
     def check(self):
-        logger.log_entry(f"Cluster: {self.cluster_name}, "
+        logger.log_entry(f"Cluster: {self.context}, "
                          f"Namespace {self.namespace}")
 
         error_messages = []

--- a/scripts/src/primazactl/utils/kubeconfigwrapper.py
+++ b/scripts/src/primazactl/utils/kubeconfigwrapper.py
@@ -8,27 +8,27 @@ class KubeConfigWrapper(object):
 
     kube_config_file: str = None
     kube_config_content = None
-    cluster_name: str = None
+    context: str = None
 
-    def __init__(self, cluster_name: str | None, kube_config_file: str):
+    def __init__(self, context: str | None, kube_config_file: str):
         self.kube_config_file = kube_config_file
-        if not cluster_name:
-            self.cluster_name = self.get_context()
-            logger.log_info(f"kcw: Use context cluster: {self.cluster_name}")
+        if not context:
+            self.context = self.get_context()
+            logger.log_info(f"kcw: Use context cluster: {self.context}")
         else:
-            self.cluster_name = cluster_name
-        logger.log_info(f"kcw: cluster: {self.cluster_name}, "
+            self.context = context
+        logger.log_info(f"kcw: cluster: {self.context}, "
                         f"file: {self.kube_config_file}")
 
     def use_context(self):
-        logger.log_entry(f"Cluster: {self.cluster_name}, "
+        logger.log_entry(f"Cluster: {self.context}, "
                          f"File : {self.kube_config_file}")
         if self.kube_config_file:
             config = KubeConfig(self.kube_config_file)
-            config.use_context(f"{self.cluster_name}")
+            config.use_context(f"{self.context}")
         else:
             config = self.get_kube_config_content_as_yaml()
-            config["current-context"] = self.cluster_name
+            config["current-context"] = self.context
 
     def get_context(self):
         if self.kube_config_file:
@@ -50,12 +50,12 @@ class KubeConfigWrapper(object):
         return self.kube_config_content
 
     def get_kubeconfig_for_content(self, content):
-        kcw = KubeConfigWrapper(self.cluster_name, None)
+        kcw = KubeConfigWrapper(self.context, None)
         kcw.kube_config_content = content
         return kcw
 
     def get_kube_config_for_cluster(self):
-        logger.log_entry(f"Cluster: {self.cluster_name}, "
+        logger.log_entry(f"Cluster: {self.context}, "
                          f"File : {self.kube_config_file}")
 
         kcc_yaml = self.get_kube_config_content_as_yaml()
@@ -63,45 +63,42 @@ class KubeConfigWrapper(object):
         cluster_config = {"apiVersion": "v1",
                           "kind": kcc_yaml["kind"],
                           "preferences": kcc_yaml["preferences"],
-                          "current-context": self.cluster_name}
+                          "current-context": self.context}
 
         logger.log_info("look through clusters")
         for cluster in kcc_yaml["clusters"]:
-            if cluster["name"] == self.cluster_name:
-                logger.log_info(f"cluster found: {self.cluster_name}")
+            if cluster["name"] == self.context:
+                logger.log_info(f"cluster found: {self.context}")
                 cluster_config["clusters"] = [cluster]
                 break
 
         logger.log_info("look through users")
         for user in kcc_yaml["users"]:
-            if user["name"] == self.cluster_name:
-                logger.log_info(f"user found: {self.cluster_name}")
+            if user["name"] == self.context:
+                logger.log_info(f"user found: {self.context}")
                 cluster_config["users"] = [user]
                 break
 
         logger.log_info("look through contexts")
         for context in kcc_yaml["contexts"]:
-            if context["name"] == self.cluster_name:
+            if context["name"] == self.context:
                 cluster_config["contexts"] = [context]
-                logger.log_info(f"context found: {self.cluster_name}")
+                logger.log_info(f"context found: {self.context}")
                 break
 
-        kcw = KubeConfigWrapper(self.cluster_name, None)
+        kcw = KubeConfigWrapper(self.context, None)
         kcw.kube_config_content = yaml.dump(cluster_config)
         # logger.log_info(f"Kubeconfig:\n{kcw.kube_config_content}")
         return kcw
 
     def copy_to_temp_file(self, temp_file):
-        logger.log_entry(f"Cluster: {self.cluster_name}, "
+        logger.log_entry(f"Cluster: {self.context}, "
                          f"File : {temp_file}")
         temp_file.write(self.get_kube_config_content().encode("utf-8"))
-        return KubeConfigWrapper(self.cluster_name, temp_file.name)
+        return KubeConfigWrapper(self.context, temp_file.name)
 
     def get_kube_config_file(self):
         return self.kube_config_file
-
-    def get_cluster_name(self):
-        return self.cluster_name
 
     def get_api_client(self) -> client:
         try:
@@ -116,7 +113,7 @@ class KubeConfigWrapper(object):
                 return cluster_only_api_client
         except Exception as e:
             msg = f"Exception getting kubernetes client for cluster " \
-                  f"{self.cluster_name} in {self.kube_config_file}. " \
+                  f"{self.context} in {self.kube_config_file}. " \
                   f"Exception was {e}"
             logger.log_error(msg)
             raise RuntimeError(f"[ERROR] {msg}")

--- a/scripts/src/primazatest/runtest.py
+++ b/scripts/src/primazatest/runtest.py
@@ -271,6 +271,7 @@ def test_application_namespace_create(venv_dir, namespace,
                    "-t", tenant,
                    "-f", config]
 
+    print("command: ", command)
     out, err = run_cmd(command)
     if err:
         print(f"[{FAIL}] Unexpected error response: {err}")
@@ -313,6 +314,7 @@ def test_service_namespace_create(venv_dir, namespace,
                    "-t", tenant,
                    "-f", config]
 
+    print("command: ", command)
     out, err = run_cmd(command)
     if err:
         print(f"[{FAIL}] Unexpected error response: {err}")
@@ -345,12 +347,12 @@ def main():
     parser.add_argument("-f", "--config",
                         dest="main_config", type=str, required=False,
                         help="main config file.")
-    parser.add_argument("-c", "--worker_cluster_name",
-                        dest="worker_cluster_name", type=str, required=True,
+    parser.add_argument("-c", "--worker_context",
+                        dest="worker_context", type=str, required=True,
                         help="name of cluster, as it appears in kubeconfig, "
                              "on which to install worker")
-    parser.add_argument("-m", "--mainclustername",
-                        dest="main_cluster_name", type=str,
+    parser.add_argument("-m", "--main_context",
+                        dest="main_context", type=str,
                         required=True,
                         help="name of cluster, as it appears in kubeconfig, "
                              "on which main is installed. "
@@ -371,27 +373,27 @@ def main():
     outcome = outcome & test_main_install(args.venv_dir,
                                           args.main_config,
                                           args.version,
-                                          args.main_cluster_name,
+                                          args.main_context,
                                           TENANT)
     outcome = outcome & test_worker_install(args.venv_dir,
                                             args.worker_config,
                                             args.version,
-                                            args.worker_cluster_name,
-                                            args.main_cluster_name,
+                                            args.worker_context,
+                                            args.main_context,
                                             TENANT)
     outcome = outcome & test_application_namespace_create(
         args.venv_dir,
         APPLICATION_NAMESPACE,
-        args.worker_cluster_name,
-        args.main_cluster_name,
+        args.worker_context,
+        args.main_context,
         TENANT,
         args.app_config,
         args.version)
     outcome = outcome & test_service_namespace_create(
         args.venv_dir,
         SERVICE_NAMESPACE,
-        args.worker_cluster_name,
-        args.main_cluster_name,
+        args.worker_context,
+        args.main_context,
         TENANT,
         args.service_config,
         args.version)


### PR DESCRIPTION
- Fix release binary corruption
- Fix primaza install command without kubeconfig
- Rename tenant flag, exit with error
- Refactor cli
- Rename cli args

Depends on #17, #18, #19, and #20

Story: https://issues.redhat.com/browse/APPSVC-1362