### PR TITLE
bump requests to v2.31.0

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.27.1
+requests==2.31.0
 polling2==0.5.0
 PyYAML==6.0
 semver==2.13.0


### PR DESCRIPTION
requests is vulnerable to CVE-2023-32681 for versions >= v2.3.0 and < 2.31.0.  Update it to not be vulnerable.