### PR TITLE
check the user has permissions required to run the script

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -29,3 +29,6 @@ jobs:
 
       - name: run test
         run: make test-local
+
+      - name: run test with users
+        run: make test-users

--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,23 @@ test-released:
 	make kind-clusters
 	$(PYTHON_VENV_DIR)/bin/primazatest -p $(PYTHON_VENV_DIR) -v $(VERSION) -c $(KUBE_KIND_CLUSTER_JOIN_NAME) -m $(KUBE_KIND_CLUSTER_TENANT_NAME)
 
+.PHONY: test-users
+test-users: setup-test create-users
+	$(PYTHON_VENV_DIR)/bin/primazatest -u -i $(OUTPUT_DIR)/users -p $(PYTHON_VENV_DIR) -e $(WORKER_CONFIG_FILE) -f $(PRIMAZA_CONFIG_FILE) -c $(KUBE_KIND_CLUSTER_JOIN_NAME) -m $(KUBE_KIND_CLUSTER_TENANT_NAME) -a $(APPLICATION_AGENT_CONFIG_FILE) -s $(SERVICE_AGENT_CONFIG_FILE)
+
+.PHONY: create-users
+create-users: primazactl
+	-rm -rf $(OUTPUT_DIR)/users
+	$(PYTHON_VENV_DIR)/bin/primazauser tenant -c $(KUBE_KIND_CLUSTER_TENANT_NAME) -o $(OUTPUT_DIR)/users
+	$(PYTHON_VENV_DIR)/bin/primazauser tenant-bad -c $(KUBE_KIND_CLUSTER_TENANT_NAME) -o $(OUTPUT_DIR)/users
+	$(PYTHON_VENV_DIR)/bin/primazauser worker -c $(KUBE_KIND_CLUSTER_JOIN_NAME) -o $(OUTPUT_DIR)/users
+	$(PYTHON_VENV_DIR)/bin/primazauser worker-bad -c $(KUBE_KIND_CLUSTER_JOIN_NAME) -o $(OUTPUT_DIR)/users
+	$(PYTHON_VENV_DIR)/bin/primazauser application-agent -c $(KUBE_KIND_CLUSTER_JOIN_NAME) -o $(OUTPUT_DIR)/users
+	$(PYTHON_VENV_DIR)/bin/primazauser application-agent-bad -c $(KUBE_KIND_CLUSTER_JOIN_NAME) -o $(OUTPUT_DIR)/users
+	$(PYTHON_VENV_DIR)/bin/primazauser service-agent -c $(KUBE_KIND_CLUSTER_JOIN_NAME) -o $(OUTPUT_DIR)/users
+	$(PYTHON_VENV_DIR)/bin/primazauser service-agent-bad -c $(KUBE_KIND_CLUSTER_JOIN_NAME) -o $(OUTPUT_DIR)/users
+
+
 .PHONY: test
 test: setup-test test-local test-released
 

--- a/README.md
+++ b/README.md
@@ -92,17 +92,20 @@ Primazactl help is organized in a hierarchy with contextual help available for d
 ## Command Summary
 
 - Create tenant
+  - checks user has the permissions required to run the command.
   - creates a specified namespace, default is `primaza-system`.
     - control-plane `primaza-controller-manager`
     - default image installed: `ghcr.io/primaza/primaza:latest`
-  - adds kubernetes resources required by primaza tenant.  
+  - adds kubernetes resources required by primaza tenant.
 - Join cluster
     - requires tenant to be created first.
+    - checks user has the permissions required to run the command.    
     - add kubernetes resources required to join a cluster.
     - creates an [identity](docs/identities.md#identities) which is shared with the primaza tenant.   
     - creates a cluster-environment resource in primaza tenant to enable communication with the joined cluster.
 - Create application-namespace.
     - requires join cluster to be complete first.
+    - checks user has the permissions required to run the command.
     - creates a specified namespace, default is `primaza-application`.
     - creates an [identity](docs/identities.md#identities) in the primaza tenant namespace which is shared with the application namespace.
         - enables primaza tenant to access the namespace
@@ -110,6 +113,7 @@ Primazactl help is organized in a hierarchy with contextual help available for d
     - provides join cluster primaza service account with access to the namespace
 - Create service-namespace.
     - requires join cluster to be complete first.
+    make p- checks user has the permissions required to run the command.
     - creates a specified namespace, default is `primaza-service`.
     - creates an [identity](docs/identities.md#identities) in the primaza tenant namespace which is shared with the service namespace.
         - enables primaza tenant to access the namespace
@@ -156,6 +160,7 @@ options:
  - `--kubeconfig KUBECONFIG` 
     - The kubeconfig file is not modified by primazactl.
     - The cluster specified for main install does not have to be the current context.
+    - Default: KUBECONFIG environment variable if set, otherwise /<home directory>/.kube/config
  - `--version VERSION`
     - Specify the version of manifests to use.
         - see: [releases](https://github.com/primaza/primazactl/releases) for available versions.    
@@ -178,7 +183,7 @@ options:
   -c CONTEXT, --context CONTEXT
                         name of cluster, as it appears in kubeconfig, on which primaza tenant was created, default: current kubeconfig context
   -k KUBECONFIG, --kubeconfig KUBECONFIG
-                        path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise /Users/martinmulholland/.kube/config
+                        path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise /<home directory>/.kube/config
 ```
 
 ### Delete tenant options
@@ -208,13 +213,13 @@ options:
   -c CONTEXT, --context CONTEXT
                         name of cluster, as it appears in kubeconfig, to join, default: current kubeconfig context
   -k KUBECONFIG, --kubeconfig KUBECONFIG
-                        path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise /Users/martinmulholland/.kube/config
+                        path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise /<home directory>/.kube/config
   -d CLUSTER_ENVIRONMENT, --cluster-environment CLUSTER_ENVIRONMENT
                         name to use for the ClusterEnvironment that will be created in Primaza
   -e ENVIRONMENT, --environment ENVIRONMENT
                         the Environment that will be associated to the ClusterEnvironment
   -l MAIN_KUBECONFIG, --tenant-kubeconfig MAIN_KUBECONFIG
-                        path to kubeconfig file for the tenant, default: KUBECONFIG environment variable if set, otherwise /Users/martinmulholland/.kube/config
+                        path to kubeconfig file for the tenant, default: KUBECONFIG environment variable if set, otherwise /<home directory>/.kube/config
   -m TENANT_CONTEXT, --tenant-context TENANT_CONTEXT
                         name of cluster, as it appears in kubeconfig, on which primaza tenant was created. Default: current kubeconfig context
   -t TENANT, --tenant TENANT
@@ -238,6 +243,7 @@ options:
 - `--kubeconfig KUBECONFIG`
     - The kubeconfig file is not modified by primazactl.
     - The cluster specified for worker join does not have to be the current context.
+    - Default: KUBECONFIG environment variable if set, otherwise /<home directory>/.kube/config
 - `--version VERSION`
     - Specify the version of manifests to use.
         - see: [releases](https://github.com/primaza/primazactl/releases) for available versions.
@@ -247,8 +253,10 @@ options:
     - name to be used for the cluster environment resource created in the primaza-main namespace.
 - `--environment ENVIRONMENT`
     - the name that will be associated to the ClusterEnvironment,
-- `--tenant-kubeconfig MAIN_KUBECONFIG`
-    - only set if the cluster on which primaza tenant installed is in a different kubeconfig file from the one set using the `--kubeconfig` option.
+- `--tenant-kubeconfig TENANT_KUBECONFIG`
+    - path to kubeconfig file for the tenant
+    - default: KUBECONFIG environment variable if set, otherwise
+      /<home directory>/.kube/config
 - `--tenant-context TENANT_CONTEXT`
     - only set if cluster on which primaza tenant is installed is different from the one set using the `--context` option.
 - `--tenant tenant`
@@ -283,6 +291,11 @@ options:
                         tenant to use. Default: primaza-system
   -v VERSION, --version VERSION
                         Version of primaza to use, default: latest. Ignored if --config is set.
+  -k KUBECONFIG, --kubeconfig KUBECONFIG
+                        path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise /Users/martinmulholland/.kube/config
+  -l TENANT_KUBECONFIG, --tenant-kubeconfig TENANT_KUBECONFIG
+                        path to kubeconfig file for the tenant, default: KUBECONFIG environment variable if set, otherwise
+                        /<home directory>/.kube/config                      
 ```
 
 ### Create application-namespace options: 
@@ -309,6 +322,15 @@ options:
         - see: [releases](https://github.com/primaza/primazactl/releases) for available versions.
         - Ignored if a config file is set.
         - Default is the version used to build primazactl.
+- `--kubeconfig KUBECONFIG`
+    - The kubeconfig file is not modified by primazactl.
+    - The cluster specified for worker join does not have to be the current context. 
+    - default: KUBECONFIG environment variable if set, otherwise
+      /<home directory>/.kube/config
+- `--tenant-kubeconfig TENANT_KUBECONFIG`
+    - path to kubeconfig file for the tenant 
+    - default: KUBECONFIG environment variable if set, otherwise
+      /<home directory>/.kube/config
     
 
 ## Create service namespace command
@@ -335,7 +357,12 @@ options:
   -t TENANT, --tenant TENANT
                         tenant to use. Default: primaza-system
   -v VERSION, --version VERSION
-                        Version of primaza to use, default: latest. Ignored if --config is set.                                                
+                        Version of primaza to use, default: latest. Ignored if --config is set.
+  -k KUBECONFIG, --kubeconfig KUBECONFIG
+                        path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise /Users/martinmulholland/.kube/config
+  -l TENANT_KUBECONFIG, --tenant-kubeconfig TENANT_KUBECONFIG
+                        path to kubeconfig file for the tenant, default: KUBECONFIG environment variable if set, otherwise
+                        /<homedirectory>/.kube/config                                                                                              
 ```
 
 ### Create service-namespace options: 
@@ -362,13 +389,26 @@ options:
         - see: [releases](https://github.com/primaza/primazactl/releases) for available versions.
         - Ignored if a config file is set.
         - Defaults to the version used to build primazactl.
+- `--kubeconfig KUBECONFIG`
+    - The kubeconfig file is not modified by primazactl.
+    - The cluster specified for worker join does not have to be the current context.
+- `--tenant-kubeconfig TENANT_KUBECONFIG`
+  path to kubeconfig file for the tenant, default: KUBECONFIG environment variable if set, otherwise
+  /<home directory>/.kube/config    
     
 # Testing
 
-- To run the tests run `make test`
+- To run the basic tests run `make test-local`
   - This will:
     - run `make setup-test`
     - run the test:  `out/venv3/bin/primazatest`
+        - src script is `scripts/src/promazatest/runtest.sh`
+        - requires inputs: python virtual environment directory, the primaza configuration file and the cluster names.
+- To run the test with users run `make test-users` 
+    - This will:
+    - run `make setup-test`
+    - run `make create-users`  
+    - run the test:  `out/venv3/bin/primazatest -u`
         - src script is `scripts/src/promazatest/runtest.sh`
         - requires inputs: python virtual environment directory, the primaza configuration file and the cluster names.
 - To set up the test environment run `make setup-test` 

--- a/README.md
+++ b/README.md
@@ -93,19 +93,22 @@ Primazactl help is organized in a hierarchy with contextual help available for d
 
 - Create tenant
   - checks user has the permissions required to run the command.
+    - if not, create tenant is not performed, and a message is output with details of missing permissions.
   - creates a specified namespace, default is `primaza-system`.
     - control-plane `primaza-controller-manager`
     - default image installed: `ghcr.io/primaza/primaza:latest`
   - adds kubernetes resources required by primaza tenant.
 - Join cluster
     - requires tenant to be created first.
-    - checks user has the permissions required to run the command.    
+    - checks user has the permissions required to run the command.
+      - if not, join cluster is not performed, and a message is output with details of missing permissions.
     - add kubernetes resources required to join a cluster.
     - creates an [identity](docs/identities.md#identities) which is shared with the primaza tenant.   
     - creates a cluster-environment resource in primaza tenant to enable communication with the joined cluster.
 - Create application-namespace.
     - requires join cluster to be complete first.
     - checks user has the permissions required to run the command.
+        - if not, create application-namespace is not performed, and a message is output with details of missing permissions.
     - creates a specified namespace, default is `primaza-application`.
     - creates an [identity](docs/identities.md#identities) in the primaza tenant namespace which is shared with the application namespace.
         - enables primaza tenant to access the namespace
@@ -113,7 +116,8 @@ Primazactl help is organized in a hierarchy with contextual help available for d
     - provides join cluster primaza service account with access to the namespace
 - Create service-namespace.
     - requires join cluster to be complete first.
-    make p- checks user has the permissions required to run the command.
+    - checks user has the permissions required to run the command.
+        - if not, create service-namespace is not performed, and a message is output with details of missing permissions.
     - creates a specified namespace, default is `primaza-service`.
     - creates an [identity](docs/identities.md#identities) in the primaza tenant namespace which is shared with the service namespace.
         - enables primaza tenant to access the namespace
@@ -409,7 +413,7 @@ options:
     - run `make setup-test`
     - run `make create-users`  
     - run the test:  `out/venv3/bin/primazatest -u`
-        - src script is `scripts/src/promazatest/runtest.sh`
+        - src script is `scripts/src/primazatest/runtest.sh`
         - requires inputs: python virtual environment directory, the primaza configuration file and the cluster names.
 - To set up the test environment run `make setup-test` 
   - This will run in order:  

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,6 +2,7 @@ requests==2.31.0
 polling2==0.5.0
 PyYAML==6.0
 semver==2.13.0
-kubernetes==25.3.0
+kubernetes==26.1.0
 kubeconfig==1.1.1
 PyGithub==1.59
+cryptography==40.0.2

--- a/scripts/setup.cfg
+++ b/scripts/setup.cfg
@@ -34,3 +34,4 @@ where = src
 console_scripts =
     primazactl = primazactl.primazactl:main
     primazatest = primazatest.runtest:main
+    primazauser = primazatest.users.user:main

--- a/scripts/src/primazactl/cmd/create/tenant/parser.py
+++ b/scripts/src/primazactl/cmd/create/tenant/parser.py
@@ -40,7 +40,8 @@ def create_tenant(args):
             args.version).install_primaza()
         print("Primaza main installed")
     except Exception as e:
-        print(traceback.format_exc())
-        print(f"\nAn exception occurred executing main install: {e}",
-              file=sys.stderr)
+        if args.verbose:
+            print(traceback.format_exc())
+            print(f"\nAn exception occurred executing main install: {e}",
+                  file=sys.stderr)
         raise e

--- a/scripts/src/primazactl/kubectl/apply.py
+++ b/scripts/src/primazactl/kubectl/apply.py
@@ -13,6 +13,15 @@ def get_method(kind, action="create", namespaced=False):
     return method
 
 
+def __get_group_and_version(api_version):
+    group, _, version = api_version.partition("/")
+    if version == "":
+        use_group = "core"
+    else:
+        use_group = group.lower()
+    return version, use_group
+
+
 def get_kube_client(api_version, api_client):
     group, _, version = api_version.partition("/")
     if version == "":
@@ -38,6 +47,7 @@ def get_kube_client(api_version, api_client):
 
 def apply_resource(resource: {}, api_client: client, action: str = "create"):
 
+    logger.log_entry(resource["metadata"]["name"])
     namespace = resource["metadata"]["namespace"] \
         if "namespace" in resource["metadata"] else ""
 
@@ -49,6 +59,8 @@ def apply_resource(resource: {}, api_client: client, action: str = "create"):
         namespaced = False
 
     resource_client = get_kube_client(resource["apiVersion"], api_client)
+
+    logger.log_info(f'{resource["apiVersion"]}, {type(resource_client)}')
 
     if isinstance(resource_client, client.CustomObjectsApi):
         group, _, version = resource["apiVersion"].partition("/")
@@ -84,24 +96,108 @@ def apply_resource(resource: {}, api_client: client, action: str = "create"):
     return resp, error
 
 
+def check_self(resource_list, api_client: client,
+               action: str = "create"):
+
+    auth_client = client.AuthorizationV1Api(api_client)
+    errors = []
+    for resource in resource_list:
+        error = __check_self_access(resource, action, auth_client)
+        if len(error) > 0:
+            errors.append(error)
+
+        if resource["kind"].lower() == "customresourcedefinition":
+
+            custom_resource = {}
+            custom_resource["apiVersion"] = f'{resource["spec"]["group"]}/v1'
+            custom_resource["kind"] = resource["spec"]["names"]["kind"]
+            custom_resource["plural"] = resource["spec"]["names"]["plural"]
+            custom_resource["metadata"] = \
+                {"name": resource["metadata"]["name"],
+                 "namespace": "kube-system"}
+            error = __check_self_access(custom_resource, action, auth_client)
+            if len(error) > 0:
+                errors.append(error)
+
+    return errors
+
+
+def __check_self_access(resource, action, auth_client):
+
+    namespace = resource["metadata"]["namespace"] \
+        if "namespace" in resource["metadata"] else ""
+
+    version, group = __get_group_and_version(resource["apiVersion"])
+
+    if "plural" in resource and len(resource["plural"]) > 0:
+        resource_kind = resource["plural"].lower()
+    else:
+        resource_kind = f'{resource["kind"].lower()}s'
+
+    body = client.V1SelfSubjectAccessReview(
+        spec=client.V1SelfSubjectAccessReviewSpec(
+            resource_attributes=client.V1ResourceAttributes(
+                resource=resource_kind,
+                verb=action,
+                name=resource["metadata"]["name"]
+            )
+        ))
+    if group and group.lower() != "core":
+        body.spec.resource_attributes.group = group.lower()
+    if namespace:
+        body.spec.resource_attributes.namespace = namespace
+
+    permission_failure = False
+    try:
+        api_response = auth_client.create_self_subject_access_review(body)
+        if api_response.status.allowed:
+            logger.log_info(f'User has permission to {action} '
+                            f'{resource["kind"]} '
+                            f'{resource["metadata"]["name"]}')
+        else:
+            logger.log_info(f'User does not have permission: {body}')
+            permission_failure = True
+
+    except ApiException as e:
+        logger.log_info("Exception when calling AuthorizationV1Api"
+                        f"->create_self_subject_access_review: {e}")
+    if permission_failure:
+        return [f"User does not have permissions to {action} "
+                f'{resource["kind"]} ',
+                f'{resource["metadata"]["name"]}"',
+                "for more information use verbose output."]
+    return []
+
+
 def apply_manifest(resource_list, client: client,
                    action: str = "create") -> []:
 
-    errors = []
-    for resource in resource_list:
-        try:
-            _, error = apply_resource(resource, client, action)
-            if error:
-                errors.append(error)
-        except ApiException as api_exception:
-            body = yaml.safe_load(api_exception.body)
-            if action == "create" and body["reason"] == "AlreadyExists":
-                # print(f'create: {body["message"]}')
-                pass
-            elif action == "read" and body["reason"] == "NotFound":
-                print(f'read: {body["message"]}')
-            elif action == "delete" and body["reason"] == "NotFound":
-                print(f'delete: {body["message"]}')
-            else:
-                errors.append(f'[ERROR] {action}: {body["message"]}')
+    errors = check_self(resource_list, client, action)
+    if len(errors) == 0:
+        for resource in resource_list:
+            try:
+                _, error = apply_resource(resource, client, action)
+                if error:
+                    logger.log_error(f"FAILED: {action} of {resource} "
+                                     f"failed: {error}")
+                    errors.append(error)
+                else:
+                    logger.log_info(f'SUCCESS: {action} of '
+                                    f'{resource["metadata"]["name"]} '
+                                    'was successful')
+            except ApiException as api_exception:
+                body = yaml.safe_load(api_exception.body)
+                if action == "create" and body["reason"] == "AlreadyExists":
+                    logger.log_info('Already Exists: create: '
+                                    f'{body["message"]}')
+                    pass
+                elif action == "read" and body["reason"] == "NotFound":
+                    logger.log_info(f'read: {body["message"]}')
+                elif action == "delete" and body["reason"] == "NotFound":
+                    logger.log_info(f'delete: {body["message"]}')
+                else:
+                    logger.log_error('FAILED with Exception: '
+                                     f'{action}: {body}')
+                    errors.append('FAILED with Exception: '
+                                  f'{action}: {body["message"]}')
     return errors

--- a/scripts/src/primazactl/kubectl/apply.py
+++ b/scripts/src/primazactl/kubectl/apply.py
@@ -190,7 +190,6 @@ def apply_manifest(resource_list, client: client,
                 if action == "create" and body["reason"] == "AlreadyExists":
                     logger.log_info('Already Exists: create: '
                                     f'{body["message"]}')
-                    pass
                 elif action == "read" and body["reason"] == "NotFound":
                     logger.log_info(f'read: {body["message"]}')
                 elif action == "delete" and body["reason"] == "NotFound":

--- a/scripts/src/primazactl/primazactl.py
+++ b/scripts/src/primazactl/primazactl.py
@@ -23,8 +23,9 @@ def main():
 
     except (argparse.ArgumentError, ValidationError) as err:
         p.error(err)
-    except Exception as err:
-        sys.stderr.write("error: %s\n" % err)
+    except Exception:
+        # arparse will output an error
+        pass
 
     sys.exit(1)
 

--- a/scripts/src/primazactl/primazaworker/workercluster.py
+++ b/scripts/src/primazactl/primazaworker/workercluster.py
@@ -1,5 +1,4 @@
 from .constants import WORKER_NAMESPACE
-from kubernetes import client
 from primazactl.primazamain.maincluster import MainCluster
 from primazactl.primaza.primazacluster import PrimazaCluster
 from primazactl.kubectl.constants import WORKER_CONFIG
@@ -56,14 +55,6 @@ class WorkerCluster(PrimazaCluster):
 
     def install_worker(self):
         logger.log_entry()
-        # need an agnostic way to get the kubeconfig - get as a parameter
-
-        api_client = self.kubeconfig.get_api_client()
-        corev1 = client.CoreV1Api(api_client)
-        api_response = corev1.list_namespace()
-        for item in api_response.items:
-            logger.log_info(f"Namespace: {item.metadata.name} is "
-                            f"make lint{item.status.phase}")
 
         if not self.context:
             self.context = self.kubeconfig.context

--- a/scripts/src/primazactl/primazaworker/workernamespace.py
+++ b/scripts/src/primazactl/primazaworker/workernamespace.py
@@ -28,6 +28,7 @@ class WorkerNamespace(PrimazaCluster):
                  namespace,
                  cluster_environment,
                  worker_cluster,
+                 kubeconfig_file,
                  role_config,
                  version,
                  main,
@@ -42,7 +43,7 @@ class WorkerNamespace(PrimazaCluster):
                          worker_cluster,
                          f"primaza-{self.type}-agent",
                          self.user_type,
-                         None,
+                         kubeconfig_file,
                          role_config,
                          cluster_environment,
                          worker.tenant)
@@ -66,8 +67,8 @@ class WorkerNamespace(PrimazaCluster):
                          f"worker cluster: {self.worker.context}")
 
         # On worker cluster
-        # - create the namespace
-        self.kube_namespace.create()
+        # - create the namespace and resources from manifest
+        self.install_config(self.manifest)
 
         # Request a new service account from primaza main
         main_identity = self.main.create_primaza_identity(
@@ -83,14 +84,6 @@ class WorkerNamespace(PrimazaCluster):
         #     and the kubeconfig for authenticating with the Primaza cluster.
 
         self.create_namespaced_kubeconfig_secret(kc, self.main.namespace)
-
-        # - In the created namespace, create the Role for the
-        #   agent (named for example primaza-application-agent or
-        #   primaza-service-agent), that will grant it access to
-        #   namespace and its resources
-        # - In the created namespace, create a RoleBinding for binding
-        #   the agents' Service Account to the role defined above
-        self.install_config(self.manifest)
 
         # - In the created namespace, create a Role (named
         #   primaza-application or primaza-service), that will grant

--- a/scripts/src/primazactl/utils/kubeconfigwrapper.py
+++ b/scripts/src/primazactl/utils/kubeconfigwrapper.py
@@ -106,7 +106,7 @@ class KubeConfigWrapper(object):
 
         kcw = KubeConfigWrapper(self.context, self.kube_config_file)
         kcw.kube_config_content = yaml.dump(cluster_config)
-        logger.log_info(f"Kubeconfig:\n{yaml.dump(cluster_config)}")
+        # logger.log_info(f"Kubeconfig:\n{yaml.dump(cluster_config)}")
         return kcw
 
     def copy_to_temp_file(self, temp_file):

--- a/scripts/src/primazactl/utils/kubeconfigwrapper.py
+++ b/scripts/src/primazactl/utils/kubeconfigwrapper.py
@@ -9,6 +9,7 @@ class KubeConfigWrapper(object):
     kube_config_file: str = None
     kube_config_content = None
     context: str = None
+    user: str = None
 
     def __init__(self, context: str | None, kube_config_file: str):
         self.kube_config_file = kube_config_file
@@ -65,42 +66,61 @@ class KubeConfigWrapper(object):
                           "preferences": kcc_yaml["preferences"],
                           "current-context": self.context}
 
-        logger.log_info("look through clusters")
-        for cluster in kcc_yaml["clusters"]:
-            if cluster["name"] == self.context:
-                logger.log_info(f"cluster found: {self.context}")
-                cluster_config["clusters"] = [cluster]
-                break
-
-        logger.log_info("look through users")
-        for user in kcc_yaml["users"]:
-            if user["name"] == self.context:
-                logger.log_info(f"user found: {self.context}")
-                cluster_config["users"] = [user]
-                break
-
-        logger.log_info("look through contexts")
+        context_cluster: str = None
         for context in kcc_yaml["contexts"]:
             if context["name"] == self.context:
                 cluster_config["contexts"] = [context]
                 logger.log_info(f"context found: {self.context}")
+                self.user = context["context"]["user"]
+                context_cluster = context["context"]["cluster"]
                 break
 
-        kcw = KubeConfigWrapper(self.context, None)
+        if self.user != self.context:
+            for context in kcc_yaml["contexts"]:
+                if context["name"] == self.user:
+                    cluster_config["contexts"].append(context)
+                    logger.log_info(f'context found: {context["name"]}')
+                    break
+
+        for cluster in kcc_yaml["clusters"]:
+            if cluster["name"] == self.context or \
+                    (context_cluster and cluster["name"] == context_cluster):
+                logger.log_info(f'cluster found: {cluster["name"]}')
+                cluster_config["clusters"] = [cluster]
+                break
+
+        if "clusters" not in cluster_config:
+            msg = f"Error cluster {self.context} not found in kube config: " \
+                  f"{self.kube_config_file}"
+            logger.log_error(msg)
+            raise RuntimeError(f"[ERROR] {msg}")
+
+        for user in kcc_yaml["users"]:
+            if user["name"] == self.context or \
+                    (self.user and user["name"] == self.user):
+                logger.log_info(f'user found: {user["name"]}')
+                if "users" in cluster_config:
+                    cluster_config["users"].append(user)
+                else:
+                    cluster_config["users"] = [user]
+
+        kcw = KubeConfigWrapper(self.context, self.kube_config_file)
         kcw.kube_config_content = yaml.dump(cluster_config)
-        # logger.log_info(f"Kubeconfig:\n{kcw.kube_config_content}")
+        logger.log_info(f"Kubeconfig:\n{yaml.dump(cluster_config)}")
         return kcw
 
     def copy_to_temp_file(self, temp_file):
         logger.log_entry(f"Cluster: {self.context}, "
-                         f"File : {temp_file}")
-        temp_file.write(self.get_kube_config_content().encode("utf-8"))
+                         f"File : {temp_file.name}")
+        temp_file.write(str(self.kube_config_content))
         return KubeConfigWrapper(self.context, temp_file.name)
 
     def get_kube_config_file(self):
         return self.kube_config_file
 
     def get_api_client(self) -> client:
+
+        logger.log_entry(self.context)
         try:
             if self.kube_config_file:
                 self.use_context()

--- a/scripts/src/primazatest/users/config/application-agent-bad.yaml
+++ b/scripts/src/primazatest/users/config/application-agent-bad.yaml
@@ -1,0 +1,163 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: primaza-app-agent-bad-admin
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: primaza-app-agent-bad-admin-cluster-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - serviceaccounts
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - update
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - create
+      - get
+      - delete
+      - update
+  - apiGroups:
+      - primaza.io
+    resources:
+      - servicebindings
+      - serviceclasses
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - primaza.io
+    resources:
+      - serviceclaims
+    verbs:
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - primaza.io
+    resources:
+      - serviceclaims/status
+      - servicebindings/status
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - primaza.io
+    resources:
+      - servicebindings/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - primaza.io
+    resources:
+      - registeredservices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resourceNames:
+      - primaza-app-agent
+    resources:
+      - deployments
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: primaza-app-agent-bad-admin-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: primaza-app-agent-bad-admin-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: primaza-app-agent-bad-admin
+    namespace: kube-system

--- a/scripts/src/primazatest/users/config/application-agent.yaml
+++ b/scripts/src/primazatest/users/config/application-agent.yaml
@@ -1,0 +1,164 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: primaza-app-agent-admin
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: primaza-app-agent-admin-cluster-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - serviceaccounts
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - update
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - create
+      - get
+      - delete
+      - update
+  - apiGroups:
+      - primaza.io
+    resources:
+      - servicebindings
+      - servicecatalogs
+      - serviceclasses
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - primaza.io
+    resources:
+      - serviceclaims
+    verbs:
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - primaza.io
+    resources:
+      - serviceclaims/status
+      - servicebindings/status
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - primaza.io
+    resources:
+      - servicebindings/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - primaza.io
+    resources:
+      - registeredservices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resourceNames:
+      - primaza-app-agent
+    resources:
+      - deployments
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: primaza-app-agent-admin-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: primaza-app-agent-admin-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: primaza-app-agent-admin
+    namespace: kube-system

--- a/scripts/src/primazatest/users/config/service-agent-bad.yaml
+++ b/scripts/src/primazatest/users/config/service-agent-bad.yaml
@@ -1,0 +1,177 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: primaza-svc-agent-bad-admin
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: primaza-svc-agent-bad-admin-cluster-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - serviceaccounts
+      - services
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - update
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - clusterroles
+      - rolebindings
+      - clusterrolebindings
+    verbs:
+      - create
+      - get
+      - delete
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - delete
+      - get
+      - update
+  - apiGroups:
+      - primaza.io
+    resources:
+      - registeredservices
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - primaza.io
+    resources:
+      - serviceclasses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - primaza.io
+    resources:
+      - servicebindings
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - primaza.io
+    resources:
+      - serviceclaims
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - update
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resourceNames:
+      - primaza-svc-agent
+    resources:
+      - deployments
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - issuers
+      - certificates
+    verbs:
+      - create
+      - delete
+      - get
+      - update
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: primaza-svc-agent-bad-admin-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: primaza-svc-agent-bad-admin-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: primaza-svc-agent-bad-admin
+    namespace: kube-system
+

--- a/scripts/src/primazatest/users/config/service-agent.yaml
+++ b/scripts/src/primazatest/users/config/service-agent.yaml
@@ -1,0 +1,188 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: primaza-svc-agent-admin
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: primaza-svc-agent-admin-cluster-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - serviceaccounts
+      - services
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - update
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - clusterroles
+      - rolebindings
+      - clusterrolebindings
+    verbs:
+      - create
+      - get
+      - delete
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - delete
+      - get
+      - update
+  - apiGroups:
+      - primaza.io
+    resources:
+      - registeredservices
+      - serviceclasses
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - primaza.io
+    resources:
+      - serviceclasses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - primaza.io
+    resources:
+      - servicebindings
+      - servicecatalogs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - primaza.io
+    resources:
+      - serviceclaims
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - update
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resourceNames:
+      - primaza-svc-agent
+    resources:
+      - deployments
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - issuers
+      - certificates
+    verbs:
+      - create
+      - delete
+      - get
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - create
+      - get
+      - delete
+      - update
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: primaza-svc-agent-admin-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: primaza-svc-agent-admin-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: primaza-svc-agent-admin
+    namespace: kube-system
+

--- a/scripts/src/primazatest/users/config/tenant-bad.yaml
+++ b/scripts/src/primazatest/users/config/tenant-bad.yaml
@@ -1,0 +1,215 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tenant-bad
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tenant-bad-cluster-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - serviceaccounts
+      - services
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - get
+      - delete
+      - update
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - get
+      - delete
+      - update
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - create
+      - get
+      - delete
+      - update
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - create
+      - get
+      - delete
+      - update
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - selfsubjectaccessreviews
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+      - delete
+  - apiGroups:
+      - primaza.io
+    resources:
+      - servicebindings
+    verbs:
+      - create
+      - get
+      - delete
+      - update
+  - apiGroups:
+      - primaza.io
+    resources:
+      - clusterenvironments
+      - servicecatalogs
+      - serviceclaims
+      - serviceclasses
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - primaza.io
+    resources:
+      - clusterenvironments/finalizers
+      - registeredservices/finalizers
+      - servicecatalogs/finalizers
+      - serviceclaims/finalizers
+      - serviceclasses/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - primaza.io
+    resources:
+      - clusterenvironments/status
+      - registeredservices/status
+      - servicecatalogs/status
+      - serviceclaims/status
+      - serviceclasses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - primaza.io.primaza.io
+    resources:
+      - servicecatalogs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - primaza.io.primaza.io
+    resources:
+      - servicecatalogs/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - primaza.io.primaza.io
+    resources:
+      - servicecatalogs/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - issuers
+      - certificates
+    verbs:
+      - create
+      - delete
+      - get
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tenant-bad-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tenant-bad-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: tenant-bad
+    namespace: kube-system

--- a/scripts/src/primazatest/users/config/tenant.yaml
+++ b/scripts/src/primazatest/users/config/tenant.yaml
@@ -1,0 +1,217 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tenant-admin
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tenant-admin-cluster-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - serviceaccounts
+      - services
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - get
+      - delete
+      - update
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - get
+      - delete
+      - update
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - create
+      - get
+      - delete
+      - update
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - create
+      - get
+      - delete
+      - update
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - selfsubjectaccessreviews
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+      - delete
+  - apiGroups:
+      - primaza.io
+    resources:
+      - servicebindings
+    verbs:
+      - create
+      - get
+      - delete
+      - update
+  - apiGroups:
+      - primaza.io
+    resources:
+      - clusterenvironments
+      - registeredservices
+      - servicecatalogs
+      - serviceclaims
+      - serviceclasses
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - primaza.io
+    resources:
+      - clusterenvironments/finalizers
+      - registeredservices/finalizers
+      - servicecatalogs/finalizers
+      - serviceclaims/finalizers
+      - serviceclasses/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - primaza.io
+    resources:
+      - clusterenvironments/status
+      - registeredservices/status
+      - servicecatalogs/status
+      - serviceclaims/status
+      - serviceclasses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - primaza.io.primaza.io
+    resources:
+      - servicecatalogs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - primaza.io.primaza.io
+    resources:
+      - servicecatalogs/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - primaza.io.primaza.io
+    resources:
+      - servicecatalogs/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - issuers
+      - certificates
+    verbs:
+      - create
+      - delete
+      - get
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tenant-admin-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tenant-admin-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: tenant-admin
+    namespace: kube-system

--- a/scripts/src/primazatest/users/config/worker-bad.yaml
+++ b/scripts/src/primazatest/users/config/worker-bad.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: primaza-worker-bad-admin
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: primaza-worker-bad-admin-role
+  namespace: kube-system
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+    - serviceaccounts
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+- apiGroups:
+    - primaza.io
+  resources:
+    - clusterenvironments
+    - registeredservices
+    - servicecatalogs
+    - serviceclaims
+    - serviceclasses
+  verbs:
+    - create
+    - delete
+    - get
+    - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: primaza-bad-admin-rolebinding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: primaza-worker-bad-admin-role
+subjects:
+  - kind: ServiceAccount
+    name: primaza-worker-bad-admin
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: primaza-worker-bad-admin-cluster-role
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - delete
+      - get
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: primaza-worker-bad-admin-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: primaza-worker-bad-admin-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: primaza-worker-bad-admin
+    namespace: kube-system

--- a/scripts/src/primazatest/users/config/worker.yaml
+++ b/scripts/src/primazatest/users/config/worker.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: primaza-worker-admin
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: primaza-worker-admin-role
+  namespace: kube-system
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+    - serviceaccounts
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+- apiGroups:
+    - primaza.io
+  resources:
+    - clusterenvironments
+    - registeredservices
+    - servicebindings
+    - servicecatalogs
+    - serviceclaims
+    - serviceclasses
+  verbs:
+    - create
+    - delete
+    - get
+    - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: primaza-admin-rolebinding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: primaza-worker-admin-role
+subjects:
+  - kind: ServiceAccount
+    name: primaza-worker-admin
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: primaza-worker-admin-cluster-role
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - delete
+      - get
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: primaza-worker-admin-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: primaza-worker-admin-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: primaza-worker-admin
+    namespace: kube-system

--- a/scripts/src/primazatest/users/user.py
+++ b/scripts/src/primazatest/users/user.py
@@ -1,0 +1,173 @@
+import yaml
+import argparse
+import os
+from kubernetes.client.rest import ApiException
+from kubernetes import client
+from primazactl.identity.kubeidentity import KubeIdentity
+from primazactl.kubectl.apply import apply_resource
+from primazactl.utils import logger
+from primazactl.utils.kubeconfigwrapper import KubeConfigWrapper
+from primazactl.utils import kubeconfig
+import inspect
+from pathlib import Path
+
+
+TENANT: str = "tenant"
+TENANT_BAD: str = "tenant-bad"
+WORKER: str = "worker"
+WORKER_BAD: str = "worker-bad"
+APP: str = "application-agent"
+APP_BAD: str = "application-agent-bad"
+SVC: str = "service-agent"
+SVC_BAD: str = "service-agent-bad"
+
+
+class User(object):
+
+    user_config_file: str = None
+    api_client: client = None
+    user_name: str = None
+    cluster_name: str = None
+    user_identity: KubeIdentity = None
+    certificate_private_key: bytes = None
+    certificate: str = None
+
+    def __init__(self, user_config_file, api_client, cluster_name):
+        self.user_config_file = user_config_file
+        self.api_client = api_client
+        self.cluster_name = cluster_name
+
+    def read_config(self):
+        logger.log_entry(f"process file: {self.user_config_file}")
+
+        with open(self.user_config_file, 'r') as manifest:
+            resources = yaml.safe_load_all(manifest)
+            resource_list = list(resources)
+
+        for resource in resource_list:
+            logger.log_info(f"process resource: {resource}")
+            if resource["kind"] == "ServiceAccount":
+                namespace = resource["metadata"]["namespace"]
+                self.user_name = resource["metadata"]["name"]
+                logger.log_info("found service account, "
+                                f"name: {self.user_name}")
+                logger.log_info("found service account, "
+                                f"namespace: {namespace}")
+                self.user_identity = KubeIdentity(self.api_client,
+                                                  self.user_name,
+                                                  f"{self.user_name}-key",
+                                                  namespace,
+                                                  self.user_name)
+
+                self.user_identity.create()
+            else:
+                try:
+                    _, error = apply_resource(resource,
+                                              self.api_client,
+                                              "delete")
+                except ApiException as api_exception:
+                    body = yaml.safe_load(api_exception.body)
+                    if body["reason"] == "NotFound":
+                        logger.log_info(f'create: {body["message"]}')
+                        pass
+                    else:
+                        logger.log_error(api_exception)
+                        raise api_exception
+
+                try:
+                    _, error = apply_resource(resource,
+                                              self.api_client,
+                                              "create")
+                except ApiException as api_exception:
+                    body = yaml.safe_load(api_exception.body)
+                    if body["reason"] == "AlreadyExists":
+                        logger.log_info(f'create: {body["message"]}')
+                        pass
+                    else:
+                        logger.log_error(api_exception)
+                        raise api_exception
+
+    def write_kubeconfig(self, new_file_path, kube_config):
+
+        logger.log_entry(f"new file path {new_file_path}")
+
+        kcd = kube_config.get_kube_config_content_as_yaml()
+        kcd["contexts"][0]["context"]["user"] = self.user_name
+        if self.user_identity:
+            idauth = self.user_identity.get_token()
+            new_user = {"user": {"token": idauth["token"]},
+                        "name": self.user_name}
+            kcd["users"][0] = new_user
+
+        os.makedirs(os.path.dirname(new_file_path), exist_ok=True)
+        with open(new_file_path, "w") as file:
+            file.write(yaml.dump(kcd))
+            logger.log_info("Write complete")
+            print(f"kubeconfig file created for user {self.user_name} : "
+                  f"{new_file_path}")
+
+
+def get_my_dir():
+    filename = inspect.getframeinfo(inspect.currentframe()).filename
+    file_path = Path(os.path.abspath(filename))
+    my_dir = ""
+    prev_dir = ""
+    for dir in file_path.parts:
+        if prev_dir == "primazactl" and dir in ["out", "scripts"]:
+            break
+        prev_dir = dir
+        my_dir = os.path.join(my_dir, dir)
+    return os.path.join(my_dir, "scripts/src/primazatest/users")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("type", type=str,
+                        choices=[TENANT, WORKER, APP, SVC, TENANT_BAD,
+                                 WORKER_BAD, APP_BAD, SVC_BAD],
+                        help='type of user to create.')
+    parser.add_argument("-c", "--cluster_name",
+                        dest="cluster_name",
+                        help="cluster name",
+                        required=True)
+    parser.add_argument("-f", "--config_file",
+                        dest="config_file",
+                        help="file with user account definition",
+                        required=False)
+    parser.add_argument("-o", "--output_dir",
+                        dest="output_dir",
+                        help="directory to output updated kubeconfig",
+                        required=False)
+    parser.add_argument("-x", "--verbose",
+                        dest="verbose",
+                        required=False,
+                        action="count",
+                        help="Set for verbose output")
+
+    args = parser.parse_args()
+
+    if hasattr(args, "verbose"):
+        logger.set_verbose(args.verbose)
+
+    if args.output_dir:
+        output_file = os.path.join(args.output_dir,
+                                   f"{args.type}-kube.config")
+    else:
+        output_file = f"./out/users/{args.type}-kube.config"
+
+    if args.config_file:
+        config_file = args.config_file
+    else:
+        config_file = os.path.join(get_my_dir(), f"config/{args.type}.yaml")
+
+    kcw = KubeConfigWrapper(args.cluster_name, kubeconfig.from_env())
+    kcw = kcw.get_kube_config_for_cluster()
+    user = User(config_file,
+                kcw.get_api_client(),
+                args.cluster_name)
+    user.read_config()
+    user.write_kubeconfig(output_file, kcw)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The PR is for 
- https://issues.redhat.com/browse/APPSVC-1286 - check user has permissiion
- https://issues.redhat.com/browse/APPSVC-1360 - add kubeconfig to all commands

Added code to check the user of primazactl has the permission required to successfully run the command.

Most of the work was in the test cases. 
Created a new set of tests which run the commands with a user which is set up as a service account with the minumum permissions required to successfully execute the command. To create the users the test runs a new command which sets up the users and creates a suitable kubeconfig file for each in `out/users`. The tests also include a run where the user does not have all of the required permissions.

Note the user for tenant, application agent and service agent all need cluster permissions because the namespace is created by the command. 

To facilitate the tests and also primazactl usability the kubeconfig flags were added to the application and service namespace commands. 